### PR TITLE
Fix frontmatter placement in overwrite mode, clean up display temp files

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This plugin shells out to a **local** model. Nothing works until these are in pl
 | Requirement | Why | Install |
 |---|---|---|
 | **ollama**, running | Does the rewriting, locally | `brew install ollama` then `ollama serve` |
-| A pulled model | The actual rewriter | `ollama pull gemma4:26b-mlx` (~17 GB; choose the model that fits into yor memory) |
+| A pulled model | The actual rewriter | `ollama pull gemma4:26b-mlx` (~17 GB; choose the model that fits into your memory) |
 | `jq` | Parses hook JSON | ships with macOS; else `brew install jq` |
 | `curl` | Talks to ollama | ships with macOS |
 
@@ -176,10 +176,20 @@ tokens/s, so a long plan or spec can take 30–120s. This hook allows up to
 still times out you get the one-time notice above — raise those limits, or set
 `CLAUDISH_MODEL` to a smaller model.
 
-```jsonc
-// enable for one directory, sibling mode (safe default), via env in the hook command
-CLAUDISH_MD_DIR=/ABS/PATH/docs/plain
+Enable it for one directory, in sibling mode (the safe default), the same way
+as every other setting — the `env` block of your `settings.json`:
+
+```json
+{
+  "env": {
+    "CLAUDISH_MD_DIR": "/ABS/PATH/docs/plain",
+    "CLAUDISH_MD_MODE": "sibling"
+  }
+}
 ```
+
+In `overwrite` mode the marker comment is written **after** any YAML
+frontmatter, so the frontmatter stays on line 1 where parsers expect it.
 
 ---
 

--- a/rewrite-md.sh
+++ b/rewrite-md.sh
@@ -110,13 +110,14 @@ esac
 content="$(cat "$file_abs" 2>/dev/null)" || pass_through "unreadable"
 dbg "candidate: $file_abs mode=$MD_MODE bytes=${#content}"
 
-# ---- idempotency: never re-chew a file we already rewrote (overwrite) -----
 first_line="$(printf '%s' "$content" | head -n1)"
-[ "$first_line" = "$MARKER" ] && pass_through "already rewritten (marker present)"
 
 # ---- protect YAML frontmatter --------------------------------------------
 # If the file opens with a '---' line and has a closing '---', hold the whole
 # frontmatter block (delimiters included) aside and rewrite only the body.
+# This runs BEFORE the idempotency check on purpose: in overwrite mode the
+# marker goes after the frontmatter, because frontmatter is only frontmatter
+# when it starts on line 1 of the file.
 fm=""
 body="$content"
 if [ "$first_line" = "---" ]; then
@@ -129,6 +130,15 @@ if [ "$first_line" = "---" ]; then
     fm=""
     dbg "frontmatter had no closing '---'; treating whole file as body"
   fi
+fi
+
+# ---- idempotency: never re-chew a file we already rewrote (overwrite) -----
+# The marker is the first non-blank line of the BODY, after any frontmatter.
+# v0.1.1 and earlier wrote it on line 1 of the file, ahead of the frontmatter;
+# that layout is still recognised so those files are not rewritten twice.
+body_first="$(printf '%s\n' "$body" | sed -n '/[^[:space:]]/{p;q;}')"
+if [ "$first_line" = "$MARKER" ] || [ "$body_first" = "$MARKER" ]; then
+  pass_through "already rewritten (marker present)"
 fi
 
 # ---- prose length gate (strip fenced code, count non-space chars) ---------
@@ -191,7 +201,8 @@ fi
 tmp="$file_abs.claudish.$$.tmp"
 if [ "$MD_MODE" = "overwrite" ]; then
   target="$file_abs"
-  { printf '%s\n' "$MARKER"; [ -n "$fm" ] && printf '%s\n\n' "$fm"; printf '%s\n' "$rewrite"; } > "$tmp" 2>/dev/null \
+  # Frontmatter first — it stops being frontmatter if anything precedes it.
+  { [ -n "$fm" ] && printf '%s\n\n' "$fm"; printf '%s\n\n' "$MARKER"; printf '%s\n' "$rewrite"; } > "$tmp" 2>/dev/null \
     || pass_through "tmp write failed"
 else
   target="${file_abs%.md}.$MD_SUFFIX.md"

--- a/rewrite.sh
+++ b/rewrite.sh
@@ -62,11 +62,14 @@ dbg() { [ "$DEBUG" = "1" ] && printf '%s [%s] %s\n' "$(date '+%H:%M:%S')" "$$" "
 # Fail-open: keep the original delta on screen.
 pass_through() { dbg "pass_through"; exit 0; }
 
-# Replace this chunk's on-screen text with $1.
+# Replace this chunk's on-screen text with $1 (a temp file, read and then
+# removed here — the opportunistic find below only sweeps buffer DIRECTORIES,
+# so without this these would pile up in TMPDIR one per assistant message).
 emit() {
   jq -n --rawfile dc "$1" \
     '{hookSpecificOutput:{hookEventName:"MessageDisplay",displayContent:$dc}}' \
-    2>/dev/null || pass_through
+    2>/dev/null || { rm -f "$1" 2>/dev/null; pass_through; }
+  rm -f "$1" 2>/dev/null
   exit 0
 }
 
@@ -91,8 +94,10 @@ tpath="$(printf '%s' "$payload" | jq -r '.transcript_path // empty' 2>/dev/null)
 [ -n "$mid" ] || pass_through
 case "$idx" in ''|*[!0-9]*) idx=0 ;; esac
 
-# Opportunistic cleanup of abandoned buffers (older than 30 min).
+# Opportunistic cleanup of abandoned buffers (older than 30 min), then of the
+# session directories they leave behind once empty.
 find "$BUF_ROOT" -mindepth 2 -maxdepth 2 -type d -mmin +30 -exec rm -rf {} + 2>/dev/null || true
+find "$BUF_ROOT" -mindepth 1 -maxdepth 1 -type d -empty -mmin +30 -exec rmdir {} + 2>/dev/null || true
 
 mdir="$BUF_ROOT/$sid/$mid"
 mkdir -p "$mdir" 2>/dev/null || pass_through
@@ -169,9 +174,11 @@ fi
 if [ -z "$rewrite" ]; then
   dbg "empty rewrite -> fail open (curl_rc=$curl_rc)"
 
-  # One-time, per-session notice when ollama itself is UNREACHABLE (curl_rc!=0:
-  # connection refused, timeout, DNS). A model error while ollama IS up
-  # (curl_rc=0, empty content) stays silent — a notice would be wrong then.
+  # One-time, per-session notice when the cause is a FIXABLE setup problem:
+  # ollama unreachable (curl_rc!=0 — connection refused, timeout, DNS), or
+  # ollama up but returning an error (curl_rc=0 with .error set, e.g. the model
+  # was never pulled). A merely empty completion — ollama up, no error — stays
+  # silent; a notice would be wrong then.
   # The notice only APPENDS one line to the original; it never suppresses
   # content, so the fail-open contract still holds.
   notified="$BUF_ROOT/$sid.notified"


### PR DESCRIPTION
Three things I hit while reading through the plugin. Happy to split this into separate PRs if you'd rather review them independently.

## 1. `overwrite` mode breaks YAML frontmatter

`rewrite-md.sh` assembled the rewritten file as marker → frontmatter → body:

```
<!-- claudish-to-english:rewritten -->
---
title: My Note
layout: post
---
```

Frontmatter only counts as frontmatter when it starts on line 1, so this stops Jekyll, Hugo, Astro and Obsidian from seeing it — the `---` block renders as ordinary body text. The README already promises frontmatter is "split off and re-attached **verbatim**", so I read this as a bug rather than a design choice.

The marker now goes *after* the frontmatter block. That moves it off line 1, so two supporting changes came with it:

- the frontmatter split now runs *before* the idempotency check
- the check looks at the first non-blank line of the **body**

Files written by 0.1.1 have their marker on line 1 ahead of the frontmatter; that layout is still recognised, so they aren't rewritten a second time. I checked this with a legacy-layout fixture.

## 2. The display hook leaks one temp file per assistant message

`emit()` writes `$TMPDIR/claudish-to-english/$sid.$mid.out` (also the `.orig` and `.notice` variants), but the opportunistic sweep matches `-type d` at depth 2 only. Those are depth-1 *files*, so nothing ever collects them — three messages left three orphaned `.out` files behind in my test.

`emit` now removes the file once jq has read it into the JSON, and empty session directories get swept alongside the message buffers.

## 3. Docs

- "choose the model that fits into **yor** memory" → "your"
- the markdown-hook enable example was fenced as `jsonc` while containing a shell assignment, and pointed at "env in the hook command" — which contradicts the Configuring section telling you not to edit `hooks/hooks.json`, since it lives in the read-only plugin cache. It now shows the same `settings.json` `env` block as every other setting.
- corrected a comment in `rewrite.sh` saying a model error with ollama up stays silent; the notice branch has covered that case since the `.error` check went in.

## Testing

Stub-mode runs of both hooks, covering: frontmatter and no-frontmatter files, sibling and overwrite modes, idempotent re-runs in each, the 0.1.1 legacy marker layout, the sibling hook skipping its own output, and the ollama-unreachable notice path (including that it only fires once per session). `bash -n` clean on both scripts.

Unrelated, so not touched here — the community marketplace install command in the README doesn't resolve yet; filed separately.
