### PR TITLE
Quote CLAUDE_PLUGIN_ROOT in hook commands

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/rewrite.sh",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}\"/rewrite.sh",
             "timeout": 60
           }
         ]
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/rewrite-md.sh",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}\"/rewrite-md.sh",
             "timeout": 180
           }
         ]


### PR DESCRIPTION
## Summary
- `hooks/hooks.json` invokes both hooks as `${CLAUDE_PLUGIN_ROOT}/rewrite.sh` / `${CLAUDE_PLUGIN_ROOT}/rewrite-md.sh`, unquoted.
- When the plugin's install/clone path contains a space (e.g. under macOS iCloud Drive's `Mobile Documents`, or any directory name with a space), the shell word-splits the expanded path when the hook command is executed. It ends up trying to exec the first word of the path as the command, so `rewrite.sh`/`rewrite-md.sh` never actually run — silently, with zero error surfaced anywhere (the plugin still loads fine and shows no errors under `/plugin`, since the JSON itself is valid).
- Quoting matches the pattern already shown in Claude Code's own [hooks reference docs](https://code.claude.com/docs/en/plugins-reference.md), which uses `"\"${CLAUDE_PLUGIN_ROOT}\"/scripts/format-code.sh"` for exactly this reason.
- Quoting is a no-op for paths without spaces, so this is safe for every install location.

## Test plan
- [x] Reproduced: confirmed via `sh -c` that an unquoted path containing spaces gets word-split, causing the hook script to never execute (verified no buffer/log directory was ever created under `$TMPDIR/claudish-to-english`).
- [x] Applied the quoting fix locally, ran `/reload-plugins`, and confirmed the "💬 In plain English:" rewrite block now appears as expected.