### PR TITLE
Document Windows setup and model default

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ are written or edited (opt-in, off by default).
 
 This plugin shells out to a **local** model. Nothing works until these are in place:
 
-### MacOS setup
+<a id="macos-setup"></a>
+<details>
+<summary><strong>macOS setup</strong></summary>
 
 | Requirement | Why | Install |
 |---|---|---|
@@ -41,14 +43,21 @@ hook appends a one-line notice on screen, and the Markdown hook shows a
 `systemMessage`. So a silent skip is never a mystery (once per session; set
 `CLAUDISH_NOTICE=0` to silence it).
 
-**Pick a model you actually have.** The default is `gemma4:26b`. Pull it, or
-pull a smaller/faster model and point the plugin at it by setting
-`CLAUDISH_MODEL` to that model's exact ollama tag in your `env` (see
+**Pick a model you actually have.** The default is `gemma4:26b-mlx`, an
+Apple-silicon (MLX) build — the right choice on a Mac, but **macOS-only**. On
+Windows it doesn't run, so you must switch to a regular tag (see
+[Windows setup](#windows-setup)). Pull it (as above), or pull a smaller/faster
+model and point the plugin at it by setting `CLAUDISH_MODEL` to that model's
+exact ollama tag in your `env` (see
 [Configuring the plugin](#configuring-the-plugin)). If `CLAUDISH_MODEL` names a
 model you have not pulled, every rewrite is skipped — with the one-time notice
 above.
 
-### Windows setup
+</details>
+
+<a id="windows-setup"></a>
+<details>
+<summary><strong>Windows setup</strong></summary>
 
 The hooks are bash scripts; on Windows, Claude Code runs them through **Git
 Bash** (Git for Windows).
@@ -64,10 +73,12 @@ Bash** (Git for Windows).
 Restart your terminal after installing so `jq`, `ollama`, and Git Bash are on
 PATH (check `jq --version` and `ollama --version`).
 
-**Do not use the macOS MLX model on Windows.** `gemma4:26b-mlx` is an
-Apple-silicon (MLX) build and doesn't exist for Windows — with it, every
-rewrite is skipped. The table above uses `gemma4:26b` as an example regular
-tag; choose another if it fits your machine better.
+> **The default model is macOS-only — Windows users must override it.** The
+> plugin's default, `gemma4:26b-mlx`, is an Apple-silicon (MLX) build that doesn't
+> run on Windows, so leaving it unset means every rewrite is silently skipped.
+> Always set `CLAUDISH_MODEL` to a regular (non-MLX) tag on Windows. The table
+> above uses `gemma4:26b` as an example; choose another if it fits your machine
+> better.
 
 Warm the model once after launching Ollama (the first call is a slow cold load):
 
@@ -93,11 +104,14 @@ Remove-Item $HOME\.claude\claudish-off               # resume
 
 (In Git Bash the `touch`/`rm` commands from that section work as-is.)
 
-Two path notes: write `CLAUDISH_MD_DIR` with forward slashes
-(`C:/dev/docs/plain`) so the bash-side path checks match, and the
-`CLAUDISH_DEBUG=1` log lands under Git Bash's temp directory
+Notes:
+- Write `CLAUDISH_MD_DIR` with forward slashes
+(`C:/dev/docs/plain`) so the bash-side path checks match
+- The `CLAUDISH_DEBUG=1` log lands under Git Bash's temp directory
 (`$TMPDIR/claudish-to-english/`, typically
 `C:\Users\<you>\AppData\Local\Temp\claudish-to-english\`).
+
+</details>
 
 ---
 
@@ -143,7 +157,7 @@ For a personal, all-projects setup, use `~/.claude/settings.json`:
 ```json
 {
   "env": {
-    "CLAUDISH_MODEL": "gemma4:26b",
+    "CLAUDISH_MODEL": "gemma4:26b-mlx",
     "CLAUDISH_MODE": "append"
   }
 }
@@ -223,7 +237,7 @@ In both modes: YAML frontmatter is split off and re-attached **verbatim**, fence
 code is left to the model instruction, short files are skipped, and the write is
 atomic. Fail-open here means the file is left **exactly as the agent wrote it**.
 
-**Large files are slow.** `gemma4:26b` (the default) rewrites at roughly 60
+**Large files are slow.** `gemma4:26b-mlx` (the default) rewrites at roughly 60
 tokens/s, so a long plan or spec can take 30–120s. This hook allows up to
 `CLAUDISH_MD_TIMEOUT` (150s) inside a 180s `PostToolUse` hook budget; if a rewrite
 still times out you get the one-time notice above — raise those limits, or set
@@ -253,7 +267,7 @@ frontmatter, so the frontmatter stays on line 1 where parsers expect it.
 | `CLAUDISH_ENABLED` | `1` | Master switch. `0` = pass everything through. Read once at session start. |
 | `CLAUDISH_OFF_FILE` | `~/.claude/claudish-off` | Runtime kill switch. While this file exists, rewrites pause — re-checked every message, so unlike env vars it works mid-session. See [Toggling mid-session](#toggling-mid-session). |
 | `CLAUDISH_MODE` | `append` | `append` or `replace` (display hook). |
-| `CLAUDISH_MODEL` | `gemma4:26b` | ollama model name. |
+| `CLAUDISH_MODEL` | `gemma4:26b-mlx` | ollama model name (MLX = Apple-silicon only; Windows users must override). |
 | `CLAUDISH_OLLAMA` | `http://localhost:11434` | ollama base URL. |
 | `CLAUDISH_MIN_CHARS` | `200` | Skip messages/files whose prose (code stripped) is shorter than this. |
 | `CLAUDISH_STUB` | `0` | `1` = deterministic stub instead of the model (for testing display mechanics). |

--- a/README.md
+++ b/README.md
@@ -18,11 +18,13 @@ are written or edited (opt-in, off by default).
 
 This plugin shells out to a **local** model. Nothing works until these are in place:
 
+### MacOS setup
+
 | Requirement | Why | Install |
 |---|---|---|
 | **ollama**, running | Does the rewriting, locally | `brew install ollama` then `ollama serve` |
 | A pulled model | The actual rewriter | `ollama pull gemma4:26b-mlx` (~17 GB; choose the model that fits into your memory) |
-| `jq` | Parses hook JSON | ships with macOS; else `brew install jq` |
+| `jq` | Parses hook JSON | ships with macOS 15+; else `brew install jq` |
 | `curl` | Talks to ollama | ships with macOS |
 
 Warm the model once after `ollama serve` (the first call is a slow cold load):
@@ -39,12 +41,63 @@ hook appends a one-line notice on screen, and the Markdown hook shows a
 `systemMessage`. So a silent skip is never a mystery (once per session; set
 `CLAUDISH_NOTICE=0` to silence it).
 
-**Pick a model you actually have.** The default is `gemma4:26b-mlx`. Pull it (as
-above), or pull a smaller/faster model and point the plugin at it by setting
+**Pick a model you actually have.** The default is `gemma4:26b`. Pull it, or
+pull a smaller/faster model and point the plugin at it by setting
 `CLAUDISH_MODEL` to that model's exact ollama tag in your `env` (see
 [Configuring the plugin](#configuring-the-plugin)). If `CLAUDISH_MODEL` names a
 model you have not pulled, every rewrite is skipped — with the one-time notice
 above.
+
+### Windows setup
+
+The hooks are bash scripts; on Windows, Claude Code runs them through **Git
+Bash** (Git for Windows).
+
+| Requirement | Why | Install |
+|---|---|---|
+| **Ollama**, running | Does the rewriting, locally | `winget install Ollama.Ollama`, then launch the Ollama app; it serves on `localhost:11434` |
+| A pulled model | The actual rewriter | `ollama pull gemma4:26b` (choose a model that fits into your memory) |
+| `jq` | Parses hook JSON | `winget install jqlang.jq` |
+| `curl` | Talks to ollama | ships with Windows 10+ |
+| Git Bash | Runs the hook scripts | Claude Code users usually already have it; else `winget install Git.Git` |
+
+Restart your terminal after installing so `jq`, `ollama`, and Git Bash are on
+PATH (check `jq --version` and `ollama --version`).
+
+**Do not use the macOS MLX model on Windows.** `gemma4:26b-mlx` is an
+Apple-silicon (MLX) build and doesn't exist for Windows — with it, every
+rewrite is skipped. The table above uses `gemma4:26b` as an example regular
+tag; choose another if it fits your machine better.
+
+Warm the model once after launching Ollama (the first call is a slow cold load):
+
+```powershell
+ollama run gemma4:26b "hi"
+```
+
+Then set `CLAUDISH_MODEL` in the `env` block of your `settings.json` (see
+[Configuring the plugin](#configuring-the-plugin) — that method is identical on
+Windows), or for a one-off session from PowerShell:
+
+```powershell
+$env:CLAUDISH_MODEL = "gemma4:26b"; claude
+```
+
+Windows equivalents of the mid-session kill switch
+([Toggling mid-session](#toggling-mid-session)):
+
+```powershell
+New-Item -ItemType File $HOME\.claude\claudish-off   # pause rewrites
+Remove-Item $HOME\.claude\claudish-off               # resume
+```
+
+(In Git Bash the `touch`/`rm` commands from that section work as-is.)
+
+Two path notes: write `CLAUDISH_MD_DIR` with forward slashes
+(`C:/dev/docs/plain`) so the bash-side path checks match, and the
+`CLAUDISH_DEBUG=1` log lands under Git Bash's temp directory
+(`$TMPDIR/claudish-to-english/`, typically
+`C:\Users\<you>\AppData\Local\Temp\claudish-to-english\`).
 
 ---
 
@@ -90,7 +143,7 @@ For a personal, all-projects setup, use `~/.claude/settings.json`:
 ```json
 {
   "env": {
-    "CLAUDISH_MODEL": "gemma4:26b-mlx",
+    "CLAUDISH_MODEL": "gemma4:26b",
     "CLAUDISH_MODE": "append"
   }
 }
@@ -170,7 +223,7 @@ In both modes: YAML frontmatter is split off and re-attached **verbatim**, fence
 code is left to the model instruction, short files are skipped, and the write is
 atomic. Fail-open here means the file is left **exactly as the agent wrote it**.
 
-**Large files are slow.** `gemma4:26b-mlx` (the default) rewrites at roughly 60
+**Large files are slow.** `gemma4:26b` (the default) rewrites at roughly 60
 tokens/s, so a long plan or spec can take 30–120s. This hook allows up to
 `CLAUDISH_MD_TIMEOUT` (150s) inside a 180s `PostToolUse` hook budget; if a rewrite
 still times out you get the one-time notice above — raise those limits, or set
@@ -200,7 +253,7 @@ frontmatter, so the frontmatter stays on line 1 where parsers expect it.
 | `CLAUDISH_ENABLED` | `1` | Master switch. `0` = pass everything through. Read once at session start. |
 | `CLAUDISH_OFF_FILE` | `~/.claude/claudish-off` | Runtime kill switch. While this file exists, rewrites pause — re-checked every message, so unlike env vars it works mid-session. See [Toggling mid-session](#toggling-mid-session). |
 | `CLAUDISH_MODE` | `append` | `append` or `replace` (display hook). |
-| `CLAUDISH_MODEL` | `gemma4:26b-mlx` | ollama model name. |
+| `CLAUDISH_MODEL` | `gemma4:26b` | ollama model name. |
 | `CLAUDISH_OLLAMA` | `http://localhost:11434` | ollama base URL. |
 | `CLAUDISH_MIN_CHARS` | `200` | Skip messages/files whose prose (code stripped) is shorter than this. |
 | `CLAUDISH_STUB` | `0` | `1` = deterministic stub instead of the model (for testing display mechanics). |


### PR DESCRIPTION
Expand README with a full Windows setup section (Ollama, jq, Git Bash, PATH checks, warm-up command, env usage, and kill-switch/path notes). Also switch the documented default model from `gemma4:26b-mlx` to cross-platform `gemma4:26b` across setup, examples, and config tables, and clarify macOS `jq` availability.