### PR TITLE
Provider layer: ollama stays default, plus any OpenAI-compatible endpoint and Anthropic

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "claudish-to-english",
       "source": "./",
-      "description": "Shows a plain-English rewrite of each Claude Code assistant message, produced by a local LLM (ollama). Display-only.",
+      "description": "Shows a plain-English rewrite of each Claude Code assistant message, produced by a local LLM (ollama, default), the Anthropic API, or any OpenAI-compatible API. Display-only.",
       "category": "productivity"
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claudish-to-english",
-  "description": "Shows a plain-English rewrite of each Claude Code assistant message, produced by a local LLM (ollama). Display-only: Claude's reasoning and the transcript keep the original text.",
+  "description": "Shows a plain-English rewrite of each Claude Code assistant message, produced by a local LLM (ollama, default), the Anthropic API, or any OpenAI-compatible API. Display-only: Claude's reasoning and the transcript keep the original text.",
   "version": "0.1.1",
   "author": {
     "name": "Mike Gvozdev",
@@ -10,5 +10,14 @@
   "homepage": "https://github.com/gvzdv/claudish-to-english#readme",
   "repository": "https://github.com/gvzdv/claudish-to-english",
   "license": "MIT",
-  "keywords": ["ollama", "local-llm", "hooks", "readability", "plain-language", "claude-code"]
+  "keywords": [
+    "ollama",
+    "local-llm",
+    "anthropic",
+    "openai",
+    "hooks",
+    "readability",
+    "plain-language",
+    "claude-code"
+  ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claudish-to-english",
   "description": "Shows a plain-English rewrite of each Claude Code assistant message, produced by a local LLM (ollama, default), the Anthropic API, or any OpenAI-compatible API. Display-only: Claude's reasoning and the transcript keep the original text.",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "author": {
     "name": "Mike Gvozdev",
     "email": "mv.gvozdev@gmail.com",

--- a/README.md
+++ b/README.md
@@ -220,15 +220,17 @@ ollama, nothing leaves your machine.
 > [!CAUTION]
 > The cloud providers pick their key up from the **ambient environment**
 > (`OPENAI_API_KEY` / `ANTHROPIC_API_KEY`), and `CLAUDISH_OPENAI_URL` defaults
-> to api.openai.com. Claude Code automatically loads a project's `.env` file
-> into the session environment — so in a project whose `.env` already contains
-> `OPENAI_API_KEY`, setting the single variable `CLAUDISH_PROVIDER=openai`
-> starts sending every assistant message (and, with the Markdown hook, file
-> contents) to OpenAI's cloud. Likewise, `CLAUDISH_PROVIDER=anthropic` will
-> quietly spend the same `ANTHROPIC_API_KEY` (and share its rate limits) that
-> other tools on your machine may rely on. Selecting a cloud provider IS the
-> consent switch — set it only when you mean it, and use the `CLAUDISH_*_KEY`
-> variables when you want the plugin on a dedicated key.
+> to api.openai.com. Anything that puts those variables into the environment
+> Claude Code launches with — an `export` in your shell profile, a tool like
+> direnv loading a project's `.env` into your shell, or the `env` block of a
+> settings file — makes them visible to this plugin. In such an environment,
+> setting the single variable `CLAUDISH_PROVIDER=openai` starts sending every
+> assistant message (and, with the Markdown hook, file contents) to OpenAI's
+> cloud. Likewise, `CLAUDISH_PROVIDER=anthropic` will quietly spend the same
+> `ANTHROPIC_API_KEY` (and share its rate limits) that other tools on your
+> machine may rely on. Selecting a cloud provider IS the consent switch — set
+> it only when you mean it, and use the `CLAUDISH_*_KEY` variables when you
+> want the plugin on a dedicated key.
 
 ```bash
 # Anthropic
@@ -257,10 +259,11 @@ Notes:
   api.openai.com — needed for models that reject `reasoning_effort` entirely.
 - The anthropic provider caps completions at `CLAUDISH_MAX_TOKENS` (default
   4096, since the Messages API requires an explicit cap).
-- A rewrite that hits an output-token cap is **discarded**, not shown: a
-  half-finished rewrite on screen is confusing, and in the Markdown hook's
-  `overwrite` mode it would replace your real document. You get the original
-  text plus the once-per-session notice suggesting a higher cap.
+- A rewrite that hits an output-token cap is **discarded**, not shown — on all
+  three providers (ollama's `done_reason: "length"` included): a half-finished
+  rewrite on screen is confusing, and in the Markdown hook's `overwrite` mode
+  it would replace your real document. You get the original text plus the
+  once-per-session notice suggesting a higher cap.
 - Every provider failure stays fail-open: missing key, bad key, unreachable
   endpoint, or timeout just leaves the original text (plus the once-per-session
   notice, unless `CLAUDISH_NOTICE=0`).

--- a/README.md
+++ b/README.md
@@ -214,8 +214,21 @@ ollama, nothing leaves your machine.
 | Provider | Endpoint | Key | Default model |
 |---|---|---|---|
 | `ollama` (default) | `CLAUDISH_OLLAMA` (`http://localhost:11434`) | none | `gemma4:26b-mlx` |
-| `anthropic` | api.anthropic.com Messages API | `CLAUDISH_ANTHROPIC_KEY` or `ANTHROPIC_API_KEY` | `claude-haiku-4-5` |
+| `anthropic` | `CLAUDISH_ANTHROPIC_URL` (`https://api.anthropic.com`) + `/v1/messages` | `CLAUDISH_ANTHROPIC_KEY` or `ANTHROPIC_API_KEY` | `claude-haiku-4-5` |
 | `openai` | `CLAUDISH_OPENAI_URL` + `/chat/completions` | `CLAUDISH_OPENAI_KEY` or `OPENAI_API_KEY` | `gpt-5.6-luna` |
+
+> [!CAUTION]
+> The cloud providers pick their key up from the **ambient environment**
+> (`OPENAI_API_KEY` / `ANTHROPIC_API_KEY`), and `CLAUDISH_OPENAI_URL` defaults
+> to api.openai.com. Claude Code automatically loads a project's `.env` file
+> into the session environment — so in a project whose `.env` already contains
+> `OPENAI_API_KEY`, setting the single variable `CLAUDISH_PROVIDER=openai`
+> starts sending every assistant message (and, with the Markdown hook, file
+> contents) to OpenAI's cloud. Likewise, `CLAUDISH_PROVIDER=anthropic` will
+> quietly spend the same `ANTHROPIC_API_KEY` (and share its rate limits) that
+> other tools on your machine may rely on. Selecting a cloud provider IS the
+> consent switch — set it only when you mean it, and use the `CLAUDISH_*_KEY`
+> variables when you want the plugin on a dedicated key.
 
 ```bash
 # Anthropic
@@ -239,9 +252,15 @@ Notes:
 - Requests to api.openai.com send `reasoning_effort: "none"` (GPT-5.6-class
   models otherwise spend reasoning tokens on a plain rewrite). Custom
   OpenAI-compatible URLs get no such field, since some local servers reject
-  unknown fields. Force one with `CLAUDISH_OPENAI_EFFORT`.
+  unknown fields. Force one with `CLAUDISH_OPENAI_EFFORT`, or set it
+  **explicitly empty** (`CLAUDISH_OPENAI_EFFORT=`) to omit the field even for
+  api.openai.com — needed for models that reject `reasoning_effort` entirely.
 - The anthropic provider caps completions at `CLAUDISH_MAX_TOKENS` (default
   4096, since the Messages API requires an explicit cap).
+- A rewrite that hits an output-token cap is **discarded**, not shown: a
+  half-finished rewrite on screen is confusing, and in the Markdown hook's
+  `overwrite` mode it would replace your real document. You get the original
+  text plus the once-per-session notice suggesting a higher cap.
 - Every provider failure stays fail-open: missing key, bad key, unreachable
   endpoint, or timeout just leaves the original text (plus the once-per-session
   notice, unless `CLAUDISH_NOTICE=0`).
@@ -264,9 +283,10 @@ Notes:
 | `CLAUDISH_OLLAMA` | `http://localhost:11434` | ollama base URL. |
 | `CLAUDISH_ANTHROPIC_KEY` | *(unset)* | Anthropic API key; falls back to `ANTHROPIC_API_KEY`. |
 | `CLAUDISH_OPENAI_KEY` | *(unset)* | OpenAI(-compatible) API key; falls back to `OPENAI_API_KEY`. Only required for api.openai.com. |
-| `CLAUDISH_OPENAI_URL` | `https://api.openai.com/v1` | Base URL for any OpenAI-compatible endpoint (LM Studio, llama.cpp server, vLLM, OpenRouter, ...). |
-| `CLAUDISH_OPENAI_EFFORT` | `none` on api.openai.com, else *(unset)* | `reasoning_effort` sent with openai-provider requests. |
-| `CLAUDISH_MAX_TOKENS` | `4096` | Completion cap for the anthropic provider. |
+| `CLAUDISH_OPENAI_URL` | `https://api.openai.com/v1` | Base URL for any OpenAI-compatible endpoint (LM Studio, llama.cpp server, vLLM, OpenRouter, ...). Trailing slashes are ignored. |
+| `CLAUDISH_ANTHROPIC_URL` | `https://api.anthropic.com` | Base URL for the anthropic provider — override for proxies/gateways that speak the Messages API. |
+| `CLAUDISH_OPENAI_EFFORT` | `none` on api.openai.com, else *(unset)* | `reasoning_effort` sent with openai-provider requests. Set explicitly empty to omit the field. |
+| `CLAUDISH_MAX_TOKENS` | `4096` | Completion cap for the anthropic provider. Rewrites that hit the cap are discarded (fail-open), with a notice to raise it. |
 | `CLAUDISH_MIN_CHARS` | `200` | Skip messages/files whose prose (code stripped) is shorter than this. |
 | `CLAUDISH_STUB` | `0` | `1` = deterministic stub instead of the model (for testing display mechanics). |
 | `CLAUDISH_TIMEOUT` | `45` | LLM client timeout for the **display** hook (seconds). Keep it below that hook's `timeout` (60s). |

--- a/README.md
+++ b/README.md
@@ -8,22 +8,27 @@
 </p>
 
 A Claude Code plugin that shows a **plain-English rewrite** of each assistant
-message, produced by a **local LLM via ollama**. It is **display-only**: Claude's
-own reasoning and the saved transcript keep the original text — only what you
-read on screen changes.
+message, produced by a **local LLM via ollama** (default), the **Anthropic
+API**, or any **OpenAI-compatible API**. It is **display-only**:
+Claude's own reasoning and the saved transcript keep the original text — only
+what you read on screen changes.
 
 An optional second hook rewrites **Markdown files** into plain English when they
 are written or edited (opt-in, off by default).
 
 > Status: working prototype. Every hook fails **open** — if anything goes wrong
-> (ollama down, timeout, missing dependency), you simply see Claude's original
-> text. The plugin can never swallow or corrupt an answer.
+> (provider down, timeout, missing key or dependency), you simply see Claude's
+> original text. The plugin can never swallow or corrupt an answer.
+
 
 ---
 
 ## Requirements (read this first)
 
-This plugin shells out to a **local** model. Nothing works until these are in place:
+With the default `ollama` provider this plugin shells out to a **local** model,
+and nothing works until these are in place. (With `CLAUDISH_PROVIDER=anthropic`
+or `openai` you need only `jq`, `curl`, and an API key — see
+[Providers](#providers).)
 
 | Requirement | Why | Install |
 |---|---|---|
@@ -200,6 +205,53 @@ frontmatter, so the frontmatter stays on line 1 where parsers expect it.
 
 ---
 
+## Providers
+
+Rewrites go through one of three providers, selected with `CLAUDISH_PROVIDER`
+(both hooks share the setting). The default is unchanged from upstream: local
+ollama, nothing leaves your machine.
+
+| Provider | Endpoint | Key | Default model |
+|---|---|---|---|
+| `ollama` (default) | `CLAUDISH_OLLAMA` (`http://localhost:11434`) | none | `gemma4:26b-mlx` |
+| `anthropic` | api.anthropic.com Messages API | `CLAUDISH_ANTHROPIC_KEY` or `ANTHROPIC_API_KEY` | `claude-haiku-4-5` |
+| `openai` | `CLAUDISH_OPENAI_URL` + `/chat/completions` | `CLAUDISH_OPENAI_KEY` or `OPENAI_API_KEY` | `gpt-5.6-luna` |
+
+```bash
+# Anthropic
+export CLAUDISH_PROVIDER=anthropic
+export ANTHROPIC_API_KEY=sk-ant-...
+
+# OpenAI
+export CLAUDISH_PROVIDER=openai
+export OPENAI_API_KEY=sk-...
+
+# Any OpenAI-compatible server (LM Studio, llama.cpp server, vLLM, OpenRouter).
+# A key is only required for api.openai.com — local servers work keyless.
+export CLAUDISH_PROVIDER=openai
+export CLAUDISH_OPENAI_URL=http://localhost:1234/v1
+export CLAUDISH_MODEL=qwen3-30b
+```
+
+Notes:
+
+- `CLAUDISH_MODEL` overrides any provider's default model.
+- Requests to api.openai.com send `reasoning_effort: "none"` (GPT-5.6-class
+  models otherwise spend reasoning tokens on a plain rewrite). Custom
+  OpenAI-compatible URLs get no such field, since some local servers reject
+  unknown fields. Force one with `CLAUDISH_OPENAI_EFFORT`.
+- The anthropic provider caps completions at `CLAUDISH_MAX_TOKENS` (default
+  4096, since the Messages API requires an explicit cap).
+- Every provider failure stays fail-open: missing key, bad key, unreachable
+  endpoint, or timeout just leaves the original text (plus the once-per-session
+  notice, unless `CLAUDISH_NOTICE=0`).
+
+> **Privacy:** the cloud providers send each assistant message (and, for the
+> Markdown hook, file contents) to an external API. Read
+> [Privacy / egress](#privacy--egress) before switching away from ollama.
+
+---
+
 ## Configuration (env vars)
 
 | Var | Default | Meaning |
@@ -207,14 +259,20 @@ frontmatter, so the frontmatter stays on line 1 where parsers expect it.
 | `CLAUDISH_ENABLED` | `1` | Master switch. `0` = pass everything through. Read once at session start. |
 | `CLAUDISH_OFF_FILE` | `~/.claude/claudish-off` | Runtime kill switch. While this file exists, rewrites pause — re-checked every message, so unlike env vars it works mid-session. See [Toggling mid-session](#toggling-mid-session). |
 | `CLAUDISH_MODE` | `append` | `append` or `replace` (display hook). |
-| `CLAUDISH_MODEL` | `gemma4:26b-mlx` | ollama model name. |
+| `CLAUDISH_PROVIDER` | `ollama` | `ollama`, `anthropic`, or `openai` — which LLM serves rewrites (both hooks). |
+| `CLAUDISH_MODEL` | *(per provider)* | Model name; overrides the provider default (see [Providers](#providers)). |
 | `CLAUDISH_OLLAMA` | `http://localhost:11434` | ollama base URL. |
+| `CLAUDISH_ANTHROPIC_KEY` | *(unset)* | Anthropic API key; falls back to `ANTHROPIC_API_KEY`. |
+| `CLAUDISH_OPENAI_KEY` | *(unset)* | OpenAI(-compatible) API key; falls back to `OPENAI_API_KEY`. Only required for api.openai.com. |
+| `CLAUDISH_OPENAI_URL` | `https://api.openai.com/v1` | Base URL for any OpenAI-compatible endpoint (LM Studio, llama.cpp server, vLLM, OpenRouter, ...). |
+| `CLAUDISH_OPENAI_EFFORT` | `none` on api.openai.com, else *(unset)* | `reasoning_effort` sent with openai-provider requests. |
+| `CLAUDISH_MAX_TOKENS` | `4096` | Completion cap for the anthropic provider. |
 | `CLAUDISH_MIN_CHARS` | `200` | Skip messages/files whose prose (code stripped) is shorter than this. |
 | `CLAUDISH_STUB` | `0` | `1` = deterministic stub instead of the model (for testing display mechanics). |
 | `CLAUDISH_TIMEOUT` | `45` | LLM client timeout for the **display** hook (seconds). Keep it below that hook's `timeout` (60s). |
 | `CLAUDISH_MD_TIMEOUT` | `150` | LLM client timeout for the **Markdown file** hook (seconds). Higher on purpose — a large model rewriting a long doc is slow. Keep it below the `PostToolUse` hook `timeout` (180s). |
 | `CLAUDISH_DEBUG` | `0` | `1` = write a debug log to `$TMPDIR/claudish-to-english/`. |
-| `CLAUDISH_NOTICE` | `1` | `1` = show a one-time, once-per-session notice when a rewrite is skipped because ollama is unreachable, the call timed out, or the model isn't pulled (display hook appends it on screen; Markdown hook uses a `systemMessage`). `0` = stay fully silent (pure fail-open). |
+| `CLAUDISH_NOTICE` | `1` | `1` = show a one-time, once-per-session notice when a rewrite is skipped because the provider is unreachable, the call timed out, a key is missing, or the model isn't available (display hook appends it on screen; Markdown hook uses a `systemMessage`). `0` = stay fully silent (pure fail-open). |
 | `CLAUDISH_MD_DIR` | *(unset)* | **Markdown hook opt-in.** Only `*.md` under this directory is rewritten. Unset = the Markdown hook does nothing. |
 | `CLAUDISH_MD_MODE` | `sibling` | `sibling` (`NAME.plain.md`) or `overwrite` (in place). |
 | `CLAUDISH_MD_SUFFIX` | `plain` | Sibling infix: `NAME.<suffix>.md`. |
@@ -250,19 +308,22 @@ sessions at once. Override the path with `CLAUDISH_OFF_FILE`.
 
 ### Reasoning models
 
-The request sends `"think": false`. Models with a hidden reasoning phase
-otherwise spend most of their time generating reasoning tokens you never see —
-much slower for identical output quality on this simple task. Keep it off.
+The ollama request sends `"think": false`, and openai-provider requests to
+api.openai.com send `reasoning_effort: "none"`. Models with a hidden reasoning
+phase otherwise spend most of their time generating reasoning tokens you never
+see — much slower for identical output quality on this simple task. Keep it off.
 
 ---
 
 ## Privacy / egress
 
-The rewriter runs **entirely locally** against ollama, so **no conversation
-content leaves your machine**. If you ever point `CLAUDISH_OLLAMA` at a
-remote/hosted endpoint, that context (which can include file contents from tool
-results) would be sent off-box — don't do that unless you understand and accept
-it.
+With the default provider the rewriter runs **entirely locally** against
+ollama, so **no conversation content leaves your machine**. Setting
+`CLAUDISH_PROVIDER` to `anthropic` or `openai` changes that deliberately: every
+rewritten assistant message (and, with the Markdown hook enabled, file
+contents) is sent to that API. The same applies to pointing `CLAUDISH_OLLAMA`
+or `CLAUDISH_OPENAI_URL` at a remote/hosted endpoint. Don't switch away from
+local unless you understand and accept it.
 
 ---
 
@@ -277,6 +338,7 @@ claudish-to-english/
 │   └── hooks.json          # MessageDisplay -> rewrite.sh ; PostToolUse -> rewrite-md.sh
 ├── rewrite.sh              # display-rewrite hook
 ├── rewrite-md.sh           # markdown-file rewrite hook (opt-in)
+├── providers.sh            # provider layer (ollama/anthropic/openai), sourced by both hooks
 ├── LICENSE
 └── README.md
 ```

--- a/providers.sh
+++ b/providers.sh
@@ -99,12 +99,16 @@ _llm_key_file() {
   _kv="${_kv//\\/\\\\}"; _kv="${_kv//\"/\\\"}"
   printf 'header = "%s: %s"\n' "$1" "$_kv" > "$_kf" 2>/dev/null \
     || { rm -f "$_kf" 2>/dev/null; return 0; }
+  # curl accepts an EMPTY -K file and would proceed unauthenticated; a partial
+  # write (ENOSPC) must therefore fail here, not at the endpoint.
+  [ -s "$_kf" ] || { rm -f "$_kf" 2>/dev/null; return 0; }
   printf '%s' "$_kf"
 }
 
 llm_complete() {
   _sys="$1"; _user="$2"
   rewrite=""; curl_rc=0; err=""; resp=""; http=""; finish=""; truncated=0
+  hdrfile=""; cfgerr=0
   case "$PROVIDER" in
     anthropic)
       if [ -z "$ANTHROPIC_KEY" ]; then dbg "anthropic: no key"; curl_rc=1; return 0; fi
@@ -114,11 +118,14 @@ llm_complete() {
       [ -n "$req" ] || return 2
       hdrfile="$(_llm_key_file "x-api-key" "$ANTHROPIC_KEY")"
       if [ -z "$hdrfile" ]; then
-        err="could not create a private temp file for the API key under ${TMPDIR:-/tmp}"
+        cfgerr=1
+        err="could not create a private temp file for the API key under ${TMPDIR:-/tmp} — nothing was sent"
         return 0
       fi
       # If the hook is killed mid-request the file must not linger in TMPDIR.
-      trap "rm -f '$hdrfile' 2>/dev/null" EXIT
+      # Single quotes: $hdrfile expands when the trap FIRES, immune to quoting
+      # in the path (it is always set — reset to "" at the top of this call).
+      trap 'rm -f "$hdrfile" 2>/dev/null' EXIT
       resp="$(printf '%s' "$req" | curl -sS --max-time "$LLM_TIMEOUT" -w '\n%{http_code}' \
               -K "$hdrfile" -H 'Content-Type: application/json' \
               -H 'anthropic-version: 2023-06-01' \
@@ -146,10 +153,11 @@ llm_complete() {
       if [ -n "$OPENAI_KEY" ]; then
         hdrfile="$(_llm_key_file "Authorization" "Bearer $OPENAI_KEY")"
         if [ -z "$hdrfile" ]; then
-          err="could not create a private temp file for the API key under ${TMPDIR:-/tmp}"
+          cfgerr=1
+          err="could not create a private temp file for the API key under ${TMPDIR:-/tmp} — nothing was sent"
           return 0
         fi
-        trap "rm -f '$hdrfile' 2>/dev/null" EXIT
+        trap 'rm -f "$hdrfile" 2>/dev/null' EXIT
         auth=(-K "$hdrfile")
       fi
       resp="$(printf '%s' "$req" | curl -sS --max-time "$LLM_TIMEOUT" -w '\n%{http_code}' \
@@ -172,6 +180,11 @@ llm_complete() {
       curl_rc=$?
       rewrite="$(printf '%s' "$resp" | jq -j '.message.content // empty' 2>/dev/null)"
       err="$(printf '%s' "$resp" | jq -r '.error // empty' 2>/dev/null)"
+      # ollama reports output-cap truncation as done_reason "length"; a
+      # half-finished rewrite must be discarded like on the cloud providers.
+      # (Response-side only — the request stays byte-identical to before.)
+      finish="$(printf '%s' "$resp" | jq -r '.done_reason // empty' 2>/dev/null)"
+      [ "$finish" = "length" ] && { truncated=1; rewrite=""; }
       ;;
   esac
 
@@ -183,6 +196,8 @@ llm_complete() {
      && [ "$curl_rc" = "0" ] && [ "$truncated" = "0" ] && [ -n "$http" ]; then
     case "$http" in
       2??) ;;
+      # Server-side trouble: the URL is probably fine, the endpoint isn't.
+      5??|429) err="HTTP $http from the endpoint — it may be down, overloaded, or rate-limiting" ;;
       *)   case "$PROVIDER" in
              anthropic) err="HTTP $http with no error message in the response — check that CLAUDISH_ANTHROPIC_URL points at an Anthropic-compatible API base URL" ;;
              *)         err="HTTP $http with no error message in the response — check that CLAUDISH_OPENAI_URL points at an OpenAI-compatible API base URL (usually ending in /v1)" ;;
@@ -201,6 +216,8 @@ llm_notice_why() {
     anthropic)
       if [ -z "$ANTHROPIC_KEY" ]; then
         NOTICE_WHY="no Anthropic API key in this session's environment (set CLAUDISH_ANTHROPIC_KEY or ANTHROPIC_API_KEY), so rewrites are off"
+      elif [ "${cfgerr:-0}" = "1" ]; then
+        NOTICE_WHY="${err:-provider configuration error}"
       elif [ "${truncated:-0}" = "1" ]; then
         NOTICE_WHY="the rewrite hit the ${MAX_TOKENS}-token output cap and was discarded rather than shown half-finished — raise CLAUDISH_MAX_TOKENS"
       elif [ -n "${err:-}" ]; then
@@ -214,8 +231,10 @@ llm_notice_why() {
     openai)
       if [ -z "$OPENAI_KEY" ] && [ "$OPENAI_URL" = "https://api.openai.com/v1" ]; then
         NOTICE_WHY="no OpenAI API key in this session's environment (set CLAUDISH_OPENAI_KEY or OPENAI_API_KEY), so rewrites are off"
+      elif [ "${cfgerr:-0}" = "1" ]; then
+        NOTICE_WHY="${err:-provider configuration error}"
       elif [ "${truncated:-0}" = "1" ]; then
-        NOTICE_WHY="the rewrite hit the model's output-token limit and was discarded rather than shown half-finished — raise the server's completion cap or use a shorter message"
+        NOTICE_WHY="the rewrite hit the model's output-token limit and was discarded rather than shown half-finished — use a shorter message, or raise the completion cap if you run the server yourself"
       elif [ -n "${err:-}" ]; then
         NOTICE_WHY="OpenAI API error: ${err}"
       elif [ "$curl_rc" = "28" ]; then
@@ -225,7 +244,12 @@ llm_notice_why() {
       fi
       ;;
     *)
-      if [ "$curl_rc" = "28" ]; then
+      # truncated first: it can only occur on a successful response, so none
+      # of the pre-existing branches (whose wording must stay byte-identical)
+      # can ever fire for the same state.
+      if [ "${truncated:-0}" = "1" ]; then
+        NOTICE_WHY="the rewrite hit ollama's output-token limit and was discarded rather than shown half-finished — raise the model's output cap (num_predict) or use a shorter message"
+      elif [ "$curl_rc" = "28" ]; then
         NOTICE_WHY="the rewrite timed out after ${LLM_TIMEOUT}s (model too slow for this message) — ${TIMEOUT_HINT:-raise the timeout or set CLAUDISH_MODEL to a smaller model}"
       elif [ "$curl_rc" != "0" ]; then
         NOTICE_WHY="can't reach ollama at $OLLAMA — start it with \`ollama serve\` (see the plugin README)"

--- a/providers.sh
+++ b/providers.sh
@@ -4,10 +4,12 @@
 # rewrite-md.sh — not executed directly.
 #
 # One function does the work: llm_complete SYSTEM USER runs a single chat
-# completion against the configured provider and sets three globals:
+# completion against the configured provider and sets these globals:
 #   rewrite   the completion text ("" on any failure)
 #   curl_rc   curl exit code (0 unless transport failed; 1 when no API key)
 #   err       provider error message ("" when none)
+#   http      HTTP status of the response ("" when unknown; cloud providers only)
+#   truncated 1 when the completion hit an output-token cap and was discarded
 # It returns 2 when the JSON request body could not be built, 0 otherwise.
 # llm_notice_why then maps a failure onto NOTICE_WHY, a one-line reason fit
 # for the once-per-session setup notice ("" when the skip should stay
@@ -16,7 +18,7 @@
 # Providers (CLAUDISH_PROVIDER):
 #   ollama     (default) local ollama at CLAUDISH_OLLAMA
 #   anthropic  Anthropic Messages API; key from CLAUDISH_ANTHROPIC_KEY or
-#              ANTHROPIC_API_KEY
+#              ANTHROPIC_API_KEY; base URL from CLAUDISH_ANTHROPIC_URL
 #   openai     any OpenAI-compatible /chat/completions endpoint (OpenAI,
 #              LM Studio, llama.cpp server, vLLM, OpenRouter, ...); base URL
 #              from CLAUDISH_OPENAI_URL, key from CLAUDISH_OPENAI_KEY or
@@ -27,11 +29,15 @@
 #   CLAUDISH_MODEL          overrides the per-provider default model
 #   CLAUDISH_MAX_TOKENS     completion cap for the anthropic provider (default
 #                           4096; the Messages API requires an explicit cap)
-#   CLAUDISH_OPENAI_EFFORT  reasoning_effort for the openai provider. Defaults
-#                           to "none" against api.openai.com (GPT-5.6-class
-#                           models otherwise burn reasoning tokens on a plain
-#                           rewrite) and to unset against custom compat URLs
-#                           (some local servers reject unknown fields).
+#   CLAUDISH_OPENAI_EFFORT  reasoning_effort for the openai provider. Unset
+#                           defaults to "none" against api.openai.com
+#                           (GPT-5.6-class models otherwise burn reasoning
+#                           tokens on a plain rewrite) and to omitted against
+#                           custom compat URLs (some local servers reject
+#                           unknown fields). Set it EMPTY
+#                           (CLAUDISH_OPENAI_EFFORT=) to force the field off
+#                           even for api.openai.com — needed for models that
+#                           reject reasoning_effort entirely.
 #
 # The caller must define dbg() and set LLM_TIMEOUT before calling
 # llm_complete, and may set TIMEOUT_HINT to customize llm_notice_why's
@@ -44,9 +50,25 @@ OLLAMA="${CLAUDISH_OLLAMA:-http://localhost:11434}"
 ANTHROPIC_KEY="${CLAUDISH_ANTHROPIC_KEY:-${ANTHROPIC_API_KEY:-}}"
 OPENAI_KEY="${CLAUDISH_OPENAI_KEY:-${OPENAI_API_KEY:-}}"
 OPENAI_URL="${CLAUDISH_OPENAI_URL:-https://api.openai.com/v1}"
+ANTHROPIC_URL="${CLAUDISH_ANTHROPIC_URL:-https://api.anthropic.com}"
 MAX_TOKENS="${CLAUDISH_MAX_TOKENS:-4096}"
-OPENAI_EFFORT="${CLAUDISH_OPENAI_EFFORT:-}"
-[ -z "$OPENAI_EFFORT" ] && [ "$OPENAI_URL" = "https://api.openai.com/v1" ] && OPENAI_EFFORT="none"
+
+# Normalize away trailing slashes BEFORE any URL comparison, so
+# ".../v1/" gets the same key requirement and effort default as ".../v1".
+while [ "${OPENAI_URL%/}" != "$OPENAI_URL" ]; do OPENAI_URL="${OPENAI_URL%/}"; done
+while [ "${ANTHROPIC_URL%/}" != "$ANTHROPIC_URL" ]; do ANTHROPIC_URL="${ANTHROPIC_URL%/}"; done
+
+# An explicitly set CLAUDISH_OPENAI_EFFORT always wins — including an
+# explicitly EMPTY one, which omits the field (the escape hatch for models
+# that reject reasoning_effort). Only when unset does the api.openai.com
+# default of "none" apply.
+if [ -n "${CLAUDISH_OPENAI_EFFORT+x}" ]; then
+  OPENAI_EFFORT="$CLAUDISH_OPENAI_EFFORT"
+elif [ "$OPENAI_URL" = "https://api.openai.com/v1" ]; then
+  OPENAI_EFFORT="none"
+else
+  OPENAI_EFFORT=""
+fi
 
 case "$PROVIDER" in
   anthropic) MODEL="${CLAUDISH_MODEL:-claude-haiku-4-5}" ;;
@@ -54,9 +76,35 @@ case "$PROVIDER" in
   *)         MODEL="${CLAUDISH_MODEL:-gemma4:26b-mlx}" ;;
 esac
 
+# Split the "\n<status>" suffix appended by curl -w '\n%{http_code}' off $resp
+# into $http. "000" (no response at all) is normalized to "".
+_llm_split_status() {
+  _nl='
+'
+  http="${resp##*"$_nl"}"
+  case "$http" in
+    [0-9][0-9][0-9]) resp="${resp%"$_nl"*}" ;;
+    *)               http="" ;;
+  esac
+  [ "$http" = "000" ] && http=""
+  return 0
+}
+
+# Write 'header = "<name>: <key>"' into a private (0600) temp file for
+# curl -K, keeping the key off the curl command line — argv is visible to
+# every local user via ps. Prints the file path; prints nothing on failure.
+_llm_key_file() {
+  _kf="$(mktemp "${TMPDIR:-/tmp}/claudish-key.XXXXXX" 2>/dev/null)" || return 0
+  _kv="$2"
+  _kv="${_kv//\\/\\\\}"; _kv="${_kv//\"/\\\"}"
+  printf 'header = "%s: %s"\n' "$1" "$_kv" > "$_kf" 2>/dev/null \
+    || { rm -f "$_kf" 2>/dev/null; return 0; }
+  printf '%s' "$_kf"
+}
+
 llm_complete() {
   _sys="$1"; _user="$2"
-  rewrite=""; curl_rc=0; err=""; resp=""
+  rewrite=""; curl_rc=0; err=""; resp=""; http=""; finish=""; truncated=0
   case "$PROVIDER" in
     anthropic)
       if [ -z "$ANTHROPIC_KEY" ]; then dbg "anthropic: no key"; curl_rc=1; return 0; fi
@@ -64,14 +112,25 @@ llm_complete() {
       req="$(jq -n --arg m "$MODEL" --argjson t "$MAX_TOKENS" --arg s "$_sys" --arg u "$_user" \
             '{model:$m,max_tokens:$t,system:$s,messages:[{role:"user",content:$u}]}' 2>/dev/null)"
       [ -n "$req" ] || return 2
-      resp="$(printf '%s' "$req" | curl -sS --max-time "$LLM_TIMEOUT" \
-              -H 'Content-Type: application/json' -H "x-api-key: ${ANTHROPIC_KEY}" \
+      hdrfile="$(_llm_key_file "x-api-key" "$ANTHROPIC_KEY")"
+      if [ -z "$hdrfile" ]; then
+        err="could not create a private temp file for the API key under ${TMPDIR:-/tmp}"
+        return 0
+      fi
+      # If the hook is killed mid-request the file must not linger in TMPDIR.
+      trap "rm -f '$hdrfile' 2>/dev/null" EXIT
+      resp="$(printf '%s' "$req" | curl -sS --max-time "$LLM_TIMEOUT" -w '\n%{http_code}' \
+              -K "$hdrfile" -H 'Content-Type: application/json' \
               -H 'anthropic-version: 2023-06-01' \
-              -X POST 'https://api.anthropic.com/v1/messages' -d @- 2>/dev/null)"
+              -X POST "$ANTHROPIC_URL/v1/messages" -d @- 2>/dev/null)"
       curl_rc=$?
+      rm -f "$hdrfile" 2>/dev/null
+      _llm_split_status
       # Join text blocks: models with thinking enabled emit non-text blocks first.
       rewrite="$(printf '%s' "$resp" | jq -j 'if (.content|type)=="array" then ([.content[] | select(.type=="text") | .text] | join("")) else empty end' 2>/dev/null)"
       err="$(printf '%s' "$resp" | jq -r '.error.message // empty' 2>/dev/null)"
+      finish="$(printf '%s' "$resp" | jq -r '.stop_reason // empty' 2>/dev/null)"
+      [ "$finish" = "max_tokens" ] && { truncated=1; rewrite=""; }
       ;;
     openai)
       if [ -z "$OPENAI_KEY" ] && [ "$OPENAI_URL" = "https://api.openai.com/v1" ]; then
@@ -84,13 +143,25 @@ llm_complete() {
              + (if $e == "" then {} else {reasoning_effort:$e} end)' 2>/dev/null)"
       [ -n "$req" ] || return 2
       auth=()
-      [ -n "$OPENAI_KEY" ] && auth+=(-H "Authorization: Bearer ${OPENAI_KEY}")
-      resp="$(printf '%s' "$req" | curl -sS --max-time "$LLM_TIMEOUT" \
+      if [ -n "$OPENAI_KEY" ]; then
+        hdrfile="$(_llm_key_file "Authorization" "Bearer $OPENAI_KEY")"
+        if [ -z "$hdrfile" ]; then
+          err="could not create a private temp file for the API key under ${TMPDIR:-/tmp}"
+          return 0
+        fi
+        trap "rm -f '$hdrfile' 2>/dev/null" EXIT
+        auth=(-K "$hdrfile")
+      fi
+      resp="$(printf '%s' "$req" | curl -sS --max-time "$LLM_TIMEOUT" -w '\n%{http_code}' \
               -H 'Content-Type: application/json' ${auth[@]+"${auth[@]}"} \
-              -X POST "${OPENAI_URL%/}/chat/completions" -d @- 2>/dev/null)"
+              -X POST "$OPENAI_URL/chat/completions" -d @- 2>/dev/null)"
       curl_rc=$?
+      [ -n "${hdrfile:-}" ] && rm -f "$hdrfile" 2>/dev/null
+      _llm_split_status
       rewrite="$(printf '%s' "$resp" | jq -j '.choices[0].message.content // empty' 2>/dev/null)"
       err="$(printf '%s' "$resp" | jq -r 'if (.error|type)=="object" then (.error.message // empty) else (.error // empty) end' 2>/dev/null)"
+      finish="$(printf '%s' "$resp" | jq -r '.choices[0].finish_reason // empty' 2>/dev/null)"
+      [ "$finish" = "length" ] && { truncated=1; rewrite=""; }
       ;;
     *)
       req="$(jq -n --arg m "$MODEL" --arg s "$_sys" --arg u "$_user" \
@@ -103,7 +174,23 @@ llm_complete() {
       err="$(printf '%s' "$resp" | jq -r '.error // empty' 2>/dev/null)"
       ;;
   esac
-  dbg "$PROVIDER model=$MODEL curl_rc=$curl_rc resp_bytes=${#resp} rewrite_bytes=${#rewrite} err=${err:-none}"
+
+  # Cloud providers: an HTTP error whose body carried no parseable message
+  # (an HTML 404 from a URL that isn't an API, a bare 502 from a proxy) must
+  # not turn into a silent skip forever — give the notice something to say.
+  # A 2xx with an empty completion stays silent, as before.
+  if [ "$PROVIDER" != "ollama" ] && [ -z "$rewrite" ] && [ -z "$err" ] \
+     && [ "$curl_rc" = "0" ] && [ "$truncated" = "0" ] && [ -n "$http" ]; then
+    case "$http" in
+      2??) ;;
+      *)   case "$PROVIDER" in
+             anthropic) err="HTTP $http with no error message in the response — check that CLAUDISH_ANTHROPIC_URL points at an Anthropic-compatible API base URL" ;;
+             *)         err="HTTP $http with no error message in the response — check that CLAUDISH_OPENAI_URL points at an OpenAI-compatible API base URL (usually ending in /v1)" ;;
+           esac ;;
+    esac
+  fi
+
+  dbg "$PROVIDER model=$MODEL curl_rc=$curl_rc http=${http:-none} resp_bytes=${#resp} rewrite_bytes=${#rewrite} truncated=$truncated err=${err:-none}"
   return 0
 }
 
@@ -114,23 +201,27 @@ llm_notice_why() {
     anthropic)
       if [ -z "$ANTHROPIC_KEY" ]; then
         NOTICE_WHY="no Anthropic API key in this session's environment (set CLAUDISH_ANTHROPIC_KEY or ANTHROPIC_API_KEY), so rewrites are off"
+      elif [ "${truncated:-0}" = "1" ]; then
+        NOTICE_WHY="the rewrite hit the ${MAX_TOKENS}-token output cap and was discarded rather than shown half-finished — raise CLAUDISH_MAX_TOKENS"
       elif [ -n "${err:-}" ]; then
         NOTICE_WHY="Anthropic API error: ${err}"
       elif [ "$curl_rc" = "28" ]; then
         NOTICE_WHY="the rewrite timed out after ${LLM_TIMEOUT}s — ${TIMEOUT_HINT:-raise the timeout}"
       elif [ "$curl_rc" != "0" ]; then
-        NOTICE_WHY="cannot reach api.anthropic.com (curl exit $curl_rc)"
+        NOTICE_WHY="cannot reach ${ANTHROPIC_URL} (curl exit $curl_rc)"
       fi
       ;;
     openai)
       if [ -z "$OPENAI_KEY" ] && [ "$OPENAI_URL" = "https://api.openai.com/v1" ]; then
         NOTICE_WHY="no OpenAI API key in this session's environment (set CLAUDISH_OPENAI_KEY or OPENAI_API_KEY), so rewrites are off"
+      elif [ "${truncated:-0}" = "1" ]; then
+        NOTICE_WHY="the rewrite hit the model's output-token limit and was discarded rather than shown half-finished — raise the server's completion cap or use a shorter message"
       elif [ -n "${err:-}" ]; then
         NOTICE_WHY="OpenAI API error: ${err}"
       elif [ "$curl_rc" = "28" ]; then
         NOTICE_WHY="the rewrite timed out after ${LLM_TIMEOUT}s — ${TIMEOUT_HINT:-raise the timeout}"
       elif [ "$curl_rc" != "0" ]; then
-        NOTICE_WHY="cannot reach ${OPENAI_URL%/} (curl exit $curl_rc)"
+        NOTICE_WHY="cannot reach ${OPENAI_URL} (curl exit $curl_rc)"
       fi
       ;;
     *)

--- a/providers.sh
+++ b/providers.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# ---------------------------------------------------------------------------
+# Provider layer for claudish-to-english. Sourced by rewrite.sh and
+# rewrite-md.sh — not executed directly.
+#
+# One function does the work: llm_complete SYSTEM USER runs a single chat
+# completion against the configured provider and sets three globals:
+#   rewrite   the completion text ("" on any failure)
+#   curl_rc   curl exit code (0 unless transport failed; 1 when no API key)
+#   err       provider error message ("" when none)
+# It returns 2 when the JSON request body could not be built, 0 otherwise.
+# llm_notice_why then maps a failure onto NOTICE_WHY, a one-line reason fit
+# for the once-per-session setup notice ("" when the skip should stay
+# silent — an empty completion with no transport error).
+#
+# Providers (CLAUDISH_PROVIDER):
+#   ollama     (default) local ollama at CLAUDISH_OLLAMA
+#   anthropic  Anthropic Messages API; key from CLAUDISH_ANTHROPIC_KEY or
+#              ANTHROPIC_API_KEY
+#   openai     any OpenAI-compatible /chat/completions endpoint (OpenAI,
+#              LM Studio, llama.cpp server, vLLM, OpenRouter, ...); base URL
+#              from CLAUDISH_OPENAI_URL, key from CLAUDISH_OPENAI_KEY or
+#              OPENAI_API_KEY. A key is only required for the default
+#              api.openai.com URL — local servers work keyless.
+#
+# Extra config:
+#   CLAUDISH_MODEL          overrides the per-provider default model
+#   CLAUDISH_MAX_TOKENS     completion cap for the anthropic provider (default
+#                           4096; the Messages API requires an explicit cap)
+#   CLAUDISH_OPENAI_EFFORT  reasoning_effort for the openai provider. Defaults
+#                           to "none" against api.openai.com (GPT-5.6-class
+#                           models otherwise burn reasoning tokens on a plain
+#                           rewrite) and to unset against custom compat URLs
+#                           (some local servers reject unknown fields).
+#
+# The caller must define dbg() and set LLM_TIMEOUT before calling
+# llm_complete, and may set TIMEOUT_HINT to customize llm_notice_why's
+# timed-out advice. Fail-open stays the caller's job: every failure here
+# comes back as an empty $rewrite, never an exit.
+# ---------------------------------------------------------------------------
+
+PROVIDER="${CLAUDISH_PROVIDER:-ollama}"
+OLLAMA="${CLAUDISH_OLLAMA:-http://localhost:11434}"
+ANTHROPIC_KEY="${CLAUDISH_ANTHROPIC_KEY:-${ANTHROPIC_API_KEY:-}}"
+OPENAI_KEY="${CLAUDISH_OPENAI_KEY:-${OPENAI_API_KEY:-}}"
+OPENAI_URL="${CLAUDISH_OPENAI_URL:-https://api.openai.com/v1}"
+MAX_TOKENS="${CLAUDISH_MAX_TOKENS:-4096}"
+OPENAI_EFFORT="${CLAUDISH_OPENAI_EFFORT:-}"
+[ -z "$OPENAI_EFFORT" ] && [ "$OPENAI_URL" = "https://api.openai.com/v1" ] && OPENAI_EFFORT="none"
+
+case "$PROVIDER" in
+  anthropic) MODEL="${CLAUDISH_MODEL:-claude-haiku-4-5}" ;;
+  openai)    MODEL="${CLAUDISH_MODEL:-gpt-5.6-luna}" ;;
+  *)         MODEL="${CLAUDISH_MODEL:-gemma4:26b-mlx}" ;;
+esac
+
+llm_complete() {
+  _sys="$1"; _user="$2"
+  rewrite=""; curl_rc=0; err=""; resp=""
+  case "$PROVIDER" in
+    anthropic)
+      if [ -z "$ANTHROPIC_KEY" ]; then dbg "anthropic: no key"; curl_rc=1; return 0; fi
+      # No temperature: current Anthropic models reject sampling parameters.
+      req="$(jq -n --arg m "$MODEL" --argjson t "$MAX_TOKENS" --arg s "$_sys" --arg u "$_user" \
+            '{model:$m,max_tokens:$t,system:$s,messages:[{role:"user",content:$u}]}' 2>/dev/null)"
+      [ -n "$req" ] || return 2
+      resp="$(printf '%s' "$req" | curl -sS --max-time "$LLM_TIMEOUT" \
+              -H 'Content-Type: application/json' -H "x-api-key: ${ANTHROPIC_KEY}" \
+              -H 'anthropic-version: 2023-06-01' \
+              -X POST 'https://api.anthropic.com/v1/messages' -d @- 2>/dev/null)"
+      curl_rc=$?
+      # Join text blocks: models with thinking enabled emit non-text blocks first.
+      rewrite="$(printf '%s' "$resp" | jq -j 'if (.content|type)=="array" then ([.content[] | select(.type=="text") | .text] | join("")) else empty end' 2>/dev/null)"
+      err="$(printf '%s' "$resp" | jq -r '.error.message // empty' 2>/dev/null)"
+      ;;
+    openai)
+      if [ -z "$OPENAI_KEY" ] && [ "$OPENAI_URL" = "https://api.openai.com/v1" ]; then
+        dbg "openai: no key"; curl_rc=1; return 0
+      fi
+      # No temperature or token cap: reasoning-tier OpenAI models reject
+      # non-default sampling, and compat servers disagree on the cap's name.
+      req="$(jq -n --arg m "$MODEL" --arg s "$_sys" --arg u "$_user" --arg e "$OPENAI_EFFORT" \
+            '{model:$m,messages:[{role:"system",content:$s},{role:"user",content:$u}]}
+             + (if $e == "" then {} else {reasoning_effort:$e} end)' 2>/dev/null)"
+      [ -n "$req" ] || return 2
+      auth=()
+      [ -n "$OPENAI_KEY" ] && auth+=(-H "Authorization: Bearer ${OPENAI_KEY}")
+      resp="$(printf '%s' "$req" | curl -sS --max-time "$LLM_TIMEOUT" \
+              -H 'Content-Type: application/json' ${auth[@]+"${auth[@]}"} \
+              -X POST "${OPENAI_URL%/}/chat/completions" -d @- 2>/dev/null)"
+      curl_rc=$?
+      rewrite="$(printf '%s' "$resp" | jq -j '.choices[0].message.content // empty' 2>/dev/null)"
+      err="$(printf '%s' "$resp" | jq -r 'if (.error|type)=="object" then (.error.message // empty) else (.error // empty) end' 2>/dev/null)"
+      ;;
+    *)
+      req="$(jq -n --arg m "$MODEL" --arg s "$_sys" --arg u "$_user" \
+            '{model:$m,stream:false,think:false,options:{temperature:0.3},messages:[{role:"system",content:$s},{role:"user",content:$u}]}' 2>/dev/null)"
+      [ -n "$req" ] || return 2
+      resp="$(printf '%s' "$req" | curl -sS --max-time "$LLM_TIMEOUT" \
+              -H 'Content-Type: application/json' -X POST "$OLLAMA/api/chat" -d @- 2>/dev/null)"
+      curl_rc=$?
+      rewrite="$(printf '%s' "$resp" | jq -j '.message.content // empty' 2>/dev/null)"
+      err="$(printf '%s' "$resp" | jq -r '.error // empty' 2>/dev/null)"
+      ;;
+  esac
+  dbg "$PROVIDER model=$MODEL curl_rc=$curl_rc resp_bytes=${#resp} rewrite_bytes=${#rewrite} err=${err:-none}"
+  return 0
+}
+
+llm_notice_why() {
+  # shellcheck disable=SC2034  # NOTICE_WHY is read by the sourcing scripts
+  NOTICE_WHY=""
+  case "$PROVIDER" in
+    anthropic)
+      if [ -z "$ANTHROPIC_KEY" ]; then
+        NOTICE_WHY="no Anthropic API key in this session's environment (set CLAUDISH_ANTHROPIC_KEY or ANTHROPIC_API_KEY), so rewrites are off"
+      elif [ -n "${err:-}" ]; then
+        NOTICE_WHY="Anthropic API error: ${err}"
+      elif [ "$curl_rc" = "28" ]; then
+        NOTICE_WHY="the rewrite timed out after ${LLM_TIMEOUT}s — ${TIMEOUT_HINT:-raise the timeout}"
+      elif [ "$curl_rc" != "0" ]; then
+        NOTICE_WHY="cannot reach api.anthropic.com (curl exit $curl_rc)"
+      fi
+      ;;
+    openai)
+      if [ -z "$OPENAI_KEY" ] && [ "$OPENAI_URL" = "https://api.openai.com/v1" ]; then
+        NOTICE_WHY="no OpenAI API key in this session's environment (set CLAUDISH_OPENAI_KEY or OPENAI_API_KEY), so rewrites are off"
+      elif [ -n "${err:-}" ]; then
+        NOTICE_WHY="OpenAI API error: ${err}"
+      elif [ "$curl_rc" = "28" ]; then
+        NOTICE_WHY="the rewrite timed out after ${LLM_TIMEOUT}s — ${TIMEOUT_HINT:-raise the timeout}"
+      elif [ "$curl_rc" != "0" ]; then
+        NOTICE_WHY="cannot reach ${OPENAI_URL%/} (curl exit $curl_rc)"
+      fi
+      ;;
+    *)
+      if [ "$curl_rc" = "28" ]; then
+        NOTICE_WHY="the rewrite timed out after ${LLM_TIMEOUT}s (model too slow for this message) — ${TIMEOUT_HINT:-raise the timeout or set CLAUDISH_MODEL to a smaller model}"
+      elif [ "$curl_rc" != "0" ]; then
+        NOTICE_WHY="can't reach ollama at $OLLAMA — start it with \`ollama serve\` (see the plugin README)"
+      elif printf '%s' "${err:-}" | grep -qi 'not found'; then
+        NOTICE_WHY="ollama model '$MODEL' isn't available — pull it with \`ollama pull $MODEL\`, or set CLAUDISH_MODEL to a model you have"
+      elif [ -n "${err:-}" ]; then
+        NOTICE_WHY="ollama returned an error: ${err}"
+      fi
+      ;;
+  esac
+}

--- a/rewrite-md.sh
+++ b/rewrite-md.sh
@@ -33,18 +33,21 @@
 #                                     Relative paths resolve against the tool's cwd.
 #   CLAUDISH_MD_MODE   sibling|overwrite   (default sibling)
 #   CLAUDISH_MD_SUFFIX <word>         sibling infix: NAME.<word>.md (default "plain")
-#   CLAUDISH_MODEL     <ollama model> (default gemma4:26b-mlx)
+#   CLAUDISH_PROVIDER  ollama|anthropic|openai  which LLM serves rewrites (default
+#                                     ollama; keys, base URLs, and per-provider model
+#                                     defaults are documented in providers.sh)
+#   CLAUDISH_MODEL     <model>        overrides the provider's default model
 #   CLAUDISH_OLLAMA    <base url>     (default http://localhost:11434)
 #   CLAUDISH_MIN_CHARS <n>            skip files whose prose (code stripped) is shorter (default 200)
-#   CLAUDISH_STUB      1|0            deterministic stub instead of ollama (mechanics testing)
+#   CLAUDISH_STUB      1|0            deterministic stub instead of the LLM (mechanics testing)
 #   CLAUDISH_MD_TIMEOUT <seconds>     LLM client timeout for file rewrites (default 150).
 #                                     Large models rewriting long docs are slow; this is
 #                                     higher than the display hook's timeout on purpose and
 #                                     must stay below the PostToolUse hook timeout in hooks.json.
 #   CLAUDISH_DEBUG     1|0            append a debug log (default 0)
 #   CLAUDISH_NOTICE    1|0            once-per-session systemMessage when a rewrite is
-#                                     skipped because ollama is unreachable, times out,
-#                                     or the model is missing (default 1)
+#                                     skipped because the provider is unreachable, times
+#                                     out, is missing a key or model (default 1)
 # ---------------------------------------------------------------------------
 set -uo pipefail
 
@@ -56,8 +59,6 @@ ENABLED="${CLAUDISH_ENABLED:-1}"
 MD_DIR="${CLAUDISH_MD_DIR:-}"
 MD_MODE="${CLAUDISH_MD_MODE:-sibling}"
 MD_SUFFIX="${CLAUDISH_MD_SUFFIX:-plain}"
-MODEL="${CLAUDISH_MODEL:-gemma4:26b-mlx}"
-OLLAMA="${CLAUDISH_OLLAMA:-http://localhost:11434}"
 MIN_CHARS="${CLAUDISH_MIN_CHARS:-200}"
 STUB="${CLAUDISH_STUB:-0}"
 LLM_TIMEOUT="${CLAUDISH_MD_TIMEOUT:-150}"
@@ -72,6 +73,10 @@ dbg() { [ "$DEBUG" = "1" ] && printf '%s [%s] %s\n' "$(date '+%H:%M:%S')" "$$" "
 
 # Fail-open: leave the file as the agent wrote it.
 pass_through() { dbg "pass_through: ${1:-}"; exit 0; }
+
+# Provider layer (ollama/anthropic/openai): MODEL/OLLAMA defaults,
+# llm_complete, llm_notice_why. Missing file -> fail open.
+. "$(cd "$(dirname "$0")" && pwd)/providers.sh" 2>/dev/null || pass_through "no providers.sh"
 
 # Print the canonical absolute path of $1 (its parent directory must exist).
 # Runs in a subshell so the cd never leaks.
@@ -164,15 +169,7 @@ if [ "$STUB" = "1" ]; then
   dbg "stub rewrite"
 else
   sys="You rewrite Markdown prose into much simpler, plain English. Keep every fact, name, number, link, and file path. Keep all Markdown structure — headings, lists, tables, and links. Do NOT change fenced code blocks or any YAML frontmatter; reproduce them exactly. Use short sentences and everyday words. Output ONLY the rewritten Markdown, with no preamble, labels, or commentary."
-  req="$(jq -n --arg m "$MODEL" --arg s "$sys" --arg u "$body" \
-        '{model:$m,stream:false,think:false,options:{temperature:0.3},messages:[{role:"system",content:$s},{role:"user",content:$u}]}' 2>/dev/null)"
-  [ -n "$req" ] || pass_through "req build failed"
-  resp="$(printf '%s' "$req" | curl -sS --max-time "$LLM_TIMEOUT" \
-          -H 'Content-Type: application/json' -X POST "$OLLAMA/api/chat" -d @- 2>/dev/null)"
-  curl_rc=$?
-  rewrite="$(printf '%s' "$resp" | jq -j '.message.content // empty' 2>/dev/null)"
-  err="$(printf '%s' "$resp" | jq -r '.error // empty' 2>/dev/null)"
-  dbg "ollama curl_rc=$curl_rc resp_bytes=${#resp} rewrite_bytes=${#rewrite} err=${err:-none}"
+  llm_complete "$sys" "$body" || pass_through "req build failed"
 fi
 
 # Empty/failed rewrite -> fail open (file left exactly as the agent wrote it).
@@ -183,16 +180,10 @@ fi
 if [ -z "$rewrite" ]; then
   notified="$LOG_ROOT/$SID.md-notified"
   if [ "$NOTICE" = "1" ] && [ ! -e "$notified" ]; then
+    TIMEOUT_HINT="raise CLAUDISH_MD_TIMEOUT (and the PostToolUse hook timeout in hooks.json), or set CLAUDISH_MODEL to a smaller model"
+    llm_notice_why
     why=""
-    if [ "$curl_rc" = "28" ]; then
-      why="rewrite of $(basename "$file") timed out after ${LLM_TIMEOUT}s — the model is too slow for a file this size. Raise CLAUDISH_MD_TIMEOUT (and the PostToolUse hook timeout in hooks.json), or set CLAUDISH_MODEL to a smaller model. File left unchanged."
-    elif [ "$curl_rc" != "0" ]; then
-      why="can't reach ollama at $OLLAMA — Markdown rewrite skipped, file left unchanged. Start it with \`ollama serve\`."
-    elif printf '%s' "${err:-}" | grep -qi 'not found'; then
-      why="ollama model '$MODEL' isn't available — Markdown rewrite skipped, file left unchanged. Pull it with \`ollama pull $MODEL\`, or set CLAUDISH_MODEL to a model you have."
-    elif [ -n "${err:-}" ]; then
-      why="ollama error while rewriting Markdown: $err. File left unchanged."
-    fi
+    [ -n "$NOTICE_WHY" ] && why="$NOTICE_WHY — Markdown rewrite of $(basename "$file") skipped, file left unchanged."
     if [ -n "$why" ]; then
       : > "$notified" 2>/dev/null || true
       jq -n --arg m "claudish-to-english: $why (shown once per session; set CLAUDISH_NOTICE=0 to silence)" \

--- a/rewrite.sh
+++ b/rewrite.sh
@@ -31,18 +31,22 @@
 #                                          ~/.claude/claudish-off) — lets a
 #                                          hotkey/script toggle mid-session
 #   CLAUDISH_MODE      append|replace display strategy (default append)
-#   CLAUDISH_MODEL     <ollama model> (default gemma4:26b-mlx)
-#   CLAUDISH_OLLAMA    <base url>     (default http://localhost:11434)
+#   CLAUDISH_PROVIDER  ollama|anthropic|openai  which LLM serves rewrites
+#                                           (default ollama; keys, base URLs,
+#                                           and per-provider model defaults
+#                                           are documented in providers.sh)
+#   CLAUDISH_MODEL     <model>         overrides the provider's default model
+#   CLAUDISH_OLLAMA    <base url>      (default http://localhost:11434)
 #   CLAUDISH_MIN_CHARS <n>            skip messages shorter than this
 #                                           (prose, code stripped) (default 200)
-#   CLAUDISH_STUB      1|0            deterministic stub instead of ollama
+#   CLAUDISH_STUB      1|0            deterministic stub instead of the LLM
 #                                           (for display-mechanics testing)
 #   CLAUDISH_TIMEOUT   <seconds>      LLM client timeout (default 45)
 #   CLAUDISH_DEBUG     1|0            write a debug log (default 0)
 #   CLAUDISH_NOTICE    1|0            once-per-session on-screen notice when the
-#                                           rewrite is skipped because ollama is
-#                                           unreachable, times out, or the model
-#                                           is missing (default 1)
+#                                           rewrite is skipped because the
+#                                           provider is unreachable, times out,
+#                                           is missing a key or model (default 1)
 # ---------------------------------------------------------------------------
 set -uo pipefail
 
@@ -52,8 +56,6 @@ ENABLED="${CLAUDISH_ENABLED:-1}"
 # every invocation. Create it to pause rewrites instantly; remove it to resume.
 [ -f "${CLAUDISH_OFF_FILE:-$HOME/.claude/claudish-off}" ] && ENABLED=0
 MODE="${CLAUDISH_MODE:-append}"
-MODEL="${CLAUDISH_MODEL:-gemma4:26b-mlx}"
-OLLAMA="${CLAUDISH_OLLAMA:-http://localhost:11434}"
 MIN_CHARS="${CLAUDISH_MIN_CHARS:-200}"
 STUB="${CLAUDISH_STUB:-0}"
 LLM_TIMEOUT="${CLAUDISH_TIMEOUT:-45}"
@@ -69,6 +71,10 @@ dbg() { [ "$DEBUG" = "1" ] && printf '%s [%s] %s\n' "$(date '+%H:%M:%S')" "$$" "
 
 # Fail-open: keep the original delta on screen.
 pass_through() { dbg "pass_through"; exit 0; }
+
+# Provider layer (ollama/anthropic/openai): MODEL/OLLAMA defaults,
+# llm_complete, llm_notice_why. Missing file -> fail open.
+. "$(cd "$(dirname "$0")" && pwd)/providers.sh" 2>/dev/null || pass_through
 
 # Replace this chunk's on-screen text with $1 (a temp file, read and then
 # removed here — the opportunistic find below only sweeps buffer DIRECTORIES,
@@ -167,15 +173,11 @@ else
     dbg "context: userq_bytes=${#userq}"
   fi
 
-  req="$(jq -n --arg m "$MODEL" --arg s "$sys" --arg u "$full" \
-        '{model:$m,stream:false,think:false,options:{temperature:0.3},messages:[{role:"system",content:$s},{role:"user",content:$u}]}' 2>/dev/null)"
-  [ -n "$req" ] || { dbg "req build failed"; cleanup; [ "$MODE" = "replace" ] && { out="$mdir.orig"; printf '%s' "$full" > "$out" && emit "$out"; }; pass_through; }
-  resp="$(printf '%s' "$req" | curl -sS --max-time "$LLM_TIMEOUT" \
-          -H 'Content-Type: application/json' -X POST "$OLLAMA/api/chat" -d @- 2>/dev/null)"
-  curl_rc=$?
-  rewrite="$(printf '%s' "$resp" | jq -j '.message.content // empty' 2>/dev/null)"
-  err="$(printf '%s' "$resp" | jq -r '.error // empty' 2>/dev/null)"
-  dbg "ollama curl_rc=$curl_rc resp_bytes=${#resp} rewrite_bytes=${#rewrite} err=${err:-none}"
+  if ! llm_complete "$sys" "$full"; then
+    dbg "req build failed"; cleanup
+    [ "$MODE" = "replace" ] && { out="$mdir.orig"; printf '%s' "$full" > "$out" && emit "$out"; }
+    pass_through
+  fi
 fi
 
 # Empty/failed rewrite -> fail open (or re-show original in replace mode).
@@ -183,26 +185,19 @@ if [ -z "$rewrite" ]; then
   dbg "empty rewrite -> fail open (curl_rc=$curl_rc)"
 
   # One-time, per-session notice when the cause is a FIXABLE setup problem:
-  # ollama unreachable (curl_rc!=0 — connection refused, timeout, DNS), or
-  # ollama up but returning an error (curl_rc=0 with .error set, e.g. the model
-  # was never pulled). A merely empty completion — ollama up, no error — stays
-  # silent; a notice would be wrong then.
-  # The notice only APPENDS one line to the original; it never suppresses
-  # content, so the fail-open contract still holds.
+  # provider unreachable (curl_rc!=0 — connection refused, timeout, DNS), a
+  # missing API key, or the provider returning an error (e.g. the ollama model
+  # was never pulled). A merely empty completion — provider up, no error —
+  # stays silent (llm_notice_why leaves NOTICE_WHY empty); a notice would be
+  # wrong then. The notice only APPENDS one line to the original; it never
+  # suppresses content, so the fail-open contract still holds.
   notified="$BUF_ROOT/$sid.notified"
-  if [ "$NOTICE" = "1" ] && [ ! -e "$notified" ] && { [ "$curl_rc" != "0" ] || [ -n "${err:-}" ]; }; then
+  TIMEOUT_HINT="raise CLAUDISH_TIMEOUT or set CLAUDISH_MODEL to a smaller model"
+  llm_notice_why
+  if [ "$NOTICE" = "1" ] && [ ! -e "$notified" ] && [ -n "$NOTICE_WHY" ]; then
     : > "$notified" 2>/dev/null || true
     last_delta="$(cat "$final_part" 2>/dev/null)"
-    if [ "$curl_rc" = "28" ]; then
-      why="the rewrite timed out after ${LLM_TIMEOUT}s (model too slow for this message) — raise CLAUDISH_TIMEOUT or set CLAUDISH_MODEL to a smaller model"
-    elif [ "$curl_rc" != "0" ]; then
-      why="can't reach ollama at $OLLAMA — start it with \`ollama serve\` (see the plugin README)"
-    elif printf '%s' "${err:-}" | grep -qi 'not found'; then
-      why="ollama model '$MODEL' isn't available — pull it with \`ollama pull $MODEL\`, or set CLAUDISH_MODEL to a model you have"
-    else
-      why="ollama returned an error: ${err:-unknown}"
-    fi
-    note=$'\n\n────────────────────────\n'"⚠️ claudish-to-english: $why. Showing Claude's original text unchanged. Shown once per session; set CLAUDISH_NOTICE=0 to silence."
+    note=$'\n\n────────────────────────\n'"⚠️ claudish-to-english: $NOTICE_WHY. Showing Claude's original text unchanged. Shown once per session; set CLAUDISH_NOTICE=0 to silence."
     out="$BUF_ROOT/$sid.$mid.notice"
     if [ "$MODE" = "replace" ]; then
       { printf '%s' "$full"; printf '%s' "$note"; } > "$out" 2>/dev/null


### PR DESCRIPTION
Hi Mike — thanks for the plugin, the fail-open design is really nice to build on.

This PR extracts the LLM call from both hooks into a shared `providers.sh` and adds two providers behind `CLAUDISH_PROVIDER`, while keeping the plugin local-first:

- **Default unchanged.** Without `CLAUDISH_PROVIDER` set, everything behaves exactly as today (ollama, `think: false`, same request, same notices).
- **`openai` = any OpenAI-compatible `/chat/completions` endpoint** via `CLAUDISH_OPENAI_URL` — that means *more local runtimes* (LM Studio, llama.cpp server, vLLM), not just the cloud. Local URLs work keyless; a key is only required for api.openai.com. Requests to api.openai.com send `reasoning_effort: "none"` so GPT-5.6-class models don't burn reasoning tokens on a plain rewrite; custom URLs get no such field since some local servers reject unknown fields.
- **`anthropic`** (Messages API, default `claude-haiku-4-5`), for people who'd rather reuse an existing key than run a local model.

Design notes:

- The fail-open contract holds on every new path: missing key, bad key, unreachable endpoint, and timeout all leave the original text, with the existing once-per-session notice now provider-aware.
- Both hooks (display + markdown) share the provider layer, so they can't drift.
- I know the plugin's identity is local/private, so the README's privacy section now says explicitly that the cloud providers send message content off-machine, and the Providers section repeats the warning.
- Version left at 0.1.1 — bumping is your call.

Testing: `bash -n` + shellcheck clean; stub tests for both hooks (append display mode, sibling md mode); fail-open integration against the real APIs with missing and invalid keys (correct notices, original text untouched, silent after the first notice).

Happy to split this differently, rename env vars, or drop the anthropic provider and keep only the OpenAI-compatible one if you prefer a smaller surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012T7URq9JnpcdxAnGRcCmXf