### PR TITLE
Add file-based custom prompt overrides (v0.3.0)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claudish-to-english",
   "description": "Shows a plain-English rewrite of each Claude Code assistant message, produced by a local LLM (ollama, default), the Anthropic API, or any OpenAI-compatible API. Display-only: Claude's reasoning and the transcript keep the original text.",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "author": {
     "name": "Mike Gvozdev",
     "email": "mv.gvozdev@gmail.com",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,62 @@
+# Changelog
+
+All notable changes to this project are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.3.0] - 2026-08-13
+
+### Added
+- Customizable rewrite prompts. Point the display hook at a prompt file with
+  `CLAUDISH_PROMPT_FILE`, or the Markdown hook with `CLAUDISH_MD_PROMPT_FILE`;
+  the file's contents replace the built-in prompt wholesale. An unset, empty, or
+  unreadable file falls back to the built-in default, so a bad path never stops
+  rewrites. Defaults are unchanged.
+
+## [0.2.0] - 2026-08-13
+
+### Added
+- Provider layer (`providers.sh`): rewrites can run against local **ollama**
+  (default, unchanged), the **Anthropic** Messages API, or any
+  **OpenAI-compatible** endpoint, selected with `CLAUDISH_PROVIDER` (#10).
+- Runtime kill-switch flag file (`~/.claude/claudish-off`, overridable with
+  `CLAUDISH_OFF_FILE`) to pause and resume rewrites mid-session, since env vars
+  are frozen at launch (#4).
+- Windows setup documentation and model-default guidance (#7).
+- Comparison screenshot at the top of the README.
+
+### Fixed
+- Markdown `overwrite` mode: the idempotency marker is written after any YAML
+  frontmatter, so the frontmatter stays on line 1 where parsers expect it.
+  Leftover display-hook temp files are also cleaned up (#1).
+- Quote `CLAUDE_PLUGIN_ROOT` in the hook commands so plugin paths containing
+  spaces resolve correctly (#6).
+
+## [0.1.1] - 2026-08-10
+
+### Added
+- One-time, per-session notice explaining why a rewrite was skipped when the
+  provider is unreachable, the call times out, or the model isn't available
+  (`CLAUDISH_NOTICE`, default on).
+
+### Changed
+- Default model set to `gemma4:26b-mlx` (Apple-silicon MLX build).
+- Separate per-hook timeouts: `CLAUDISH_TIMEOUT` (display) and
+  `CLAUDISH_MD_TIMEOUT` (Markdown file).
+- Added the "Configuring the plugin" section to the README.
+
+## [0.1.0] - 2026-08-10
+
+### Added
+- Initial release. A `MessageDisplay` hook (`rewrite.sh`) that rewrites each
+  assistant message into plain English with a local ollama model — `append`
+  and `replace` display modes, a prose-length gate, and a fail-open contract
+  that always leaves Claude's original text on screen if anything goes wrong.
+- Optional `PostToolUse` Markdown-file rewrite hook (`rewrite-md.sh`), opt-in by
+  directory (`CLAUDISH_MD_DIR`), with `sibling` and `overwrite` modes.
+
+[0.3.0]: https://github.com/gvzdv/claudish-to-english/compare/v0.2.0...v0.3.0
+[0.2.0]: https://github.com/gvzdv/claudish-to-english/compare/v0.1.1...v0.2.0
+[0.1.1]: https://github.com/gvzdv/claudish-to-english/compare/v0.1.0...v0.1.1
+[0.1.0]: https://github.com/gvzdv/claudish-to-english/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -199,6 +199,42 @@ To confirm the hook is firing, set `CLAUDISH_DEBUG=1` and watch
 
 ---
 
+## Customizing the rewrite prompt
+
+Each hook ships with a default system prompt that asks the model for plain
+English while preserving facts, code, and structure. You can **replace** either
+prompt with your own to add specific rules or use wording that works
+better with your model. To do so, point the hook at a file that holds
+the prompt:
+
+| Hook | Prompt file |
+|---|---|
+| Display (`rewrite.sh`) | `CLAUDISH_PROMPT_FILE` |
+| Markdown (`rewrite-md.sh`) | `CLAUDISH_MD_PROMPT_FILE` |
+
+The file's contents **replace** the built-in prompt, so
+include every instruction you want the model to follow — otherwise the defaults
+(keep facts, leave code blocks alone, output only the rewrite) are gone. Keeping
+the prompt in a file avoids escaping a long, multi-line prompt inside a JSON
+string. If the variable is unset, or the file is empty or unreadable, the hook
+falls back to its built-in default, so a bad path never stops rewrites.
+
+```json
+{
+  "env": {
+    "CLAUDISH_PROMPT_FILE": "/ABS/PATH/prompts/plain.txt",
+    "CLAUDISH_MD_PROMPT_FILE": "/ABS/PATH/prompts/md-plain.txt"
+  }
+}
+```
+
+The display hook still appends the **original user question** to your prompt, as
+context to keep the rewrite on-topic (see
+[How the display hook works](#how-the-display-hook-works)). Your prompt
+replaces only the base instruction.
+
+---
+
 ## How the display hook works
 
 Claude Code fires the `MessageDisplay` event **once per streamed chunk**, not
@@ -354,6 +390,7 @@ Notes:
 | `CLAUDISH_ENABLED` | `1` | Master switch. `0` = pass everything through. Read once at session start. |
 | `CLAUDISH_OFF_FILE` | `~/.claude/claudish-off` | Runtime kill switch. While this file exists, rewrites pause — re-checked every message, so unlike env vars it works mid-session. See [Toggling mid-session](#toggling-mid-session). |
 | `CLAUDISH_MODE` | `append` | `append` or `replace` (display hook). |
+| `CLAUDISH_PROMPT_FILE` | *(unset)* | Path to a file whose contents replace the display hook's system prompt (whole prompt, not merged). Empty/unreadable falls back to the built-in default. See [Customizing the rewrite prompt](#customizing-the-rewrite-prompt). |
 | `CLAUDISH_PROVIDER` | `ollama` | `ollama`, `anthropic`, or `openai` — which LLM serves rewrites (both hooks). |
 | `CLAUDISH_MODEL` | *(per provider)* | Model name; overrides the provider default (see [Providers](#providers)). The ollama default `gemma4:26b-mlx` is MLX (Apple-silicon only; Windows users must override). |
 | `CLAUDISH_OLLAMA` | `http://localhost:11434` | ollama base URL. |
@@ -372,6 +409,7 @@ Notes:
 | `CLAUDISH_MD_DIR` | *(unset)* | **Markdown hook opt-in.** Only `*.md` under this directory is rewritten. Unset = the Markdown hook does nothing. |
 | `CLAUDISH_MD_MODE` | `sibling` | `sibling` (`NAME.plain.md`) or `overwrite` (in place). |
 | `CLAUDISH_MD_SUFFIX` | `plain` | Sibling infix: `NAME.<suffix>.md`. |
+| `CLAUDISH_MD_PROMPT_FILE` | *(unset)* | Path to a file whose contents replace the Markdown hook's system prompt (whole prompt, not merged). Empty/unreadable falls back to the built-in default. |
 
 In `hooks/hooks.json` the display hook (`MessageDisplay`) has a 60s `timeout` and
 the Markdown hook (`PostToolUse`) has a 180s `timeout` — the file hook is higher
@@ -435,6 +473,7 @@ claudish-to-english/
 ├── rewrite.sh              # display-rewrite hook
 ├── rewrite-md.sh           # markdown-file rewrite hook (opt-in)
 ├── providers.sh            # provider layer (ollama/anthropic/openai), sourced by both hooks
+├── CHANGELOG.md            # notable changes per version (Keep a Changelog)
 ├── LICENSE
 └── README.md
 ```

--- a/rewrite-md.sh
+++ b/rewrite-md.sh
@@ -33,6 +33,9 @@
 #                                     Relative paths resolve against the tool's cwd.
 #   CLAUDISH_MD_MODE   sibling|overwrite   (default sibling)
 #   CLAUDISH_MD_SUFFIX <word>         sibling infix: NAME.<word>.md (default "plain")
+#   CLAUDISH_MD_PROMPT_FILE <path>    file holding a replacement Markdown prompt
+#                                     (whole prompt, not merged; empty or
+#                                     unreadable -> built-in default)
 #   CLAUDISH_PROVIDER  ollama|anthropic|openai  which LLM serves rewrites (default
 #                                     ollama; keys, base URLs, and per-provider model
 #                                     defaults are documented in providers.sh)
@@ -168,7 +171,18 @@ if [ "$STUB" = "1" ]; then
   rewrite="STUB-SIMPLIFIED-MD ✦ mode=$MD_MODE prose_len=$prose_len ✦"$'\n\n'"$body"
   dbg "stub rewrite"
 else
+  # Base system prompt, replaceable via CLAUDISH_MD_PROMPT_FILE (a file holding
+  # the whole prompt). An unset/empty/unreadable file falls back to this default.
   sys="You rewrite Markdown prose into much simpler, plain English. Keep every fact, name, number, link, and file path. Keep all Markdown structure — headings, lists, tables, and links. Do NOT change fenced code blocks or any YAML frontmatter; reproduce them exactly. Use short sentences and everyday words. Output ONLY the rewritten Markdown, with no preamble, labels, or commentary."
+  if [ -n "${CLAUDISH_MD_PROMPT_FILE:-}" ]; then
+    _p=""
+    [ -r "$CLAUDISH_MD_PROMPT_FILE" ] && _p="$(cat "$CLAUDISH_MD_PROMPT_FILE" 2>/dev/null)"
+    if [ -n "$_p" ]; then
+      sys="$_p"
+    else
+      dbg "CLAUDISH_MD_PROMPT_FILE set but empty/unreadable ($CLAUDISH_MD_PROMPT_FILE); using default prompt"
+    fi
+  fi
   llm_complete "$sys" "$body" || pass_through "req build failed"
 fi
 

--- a/rewrite.sh
+++ b/rewrite.sh
@@ -31,6 +31,9 @@
 #                                          ~/.claude/claudish-off) — lets a
 #                                          hotkey/script toggle mid-session
 #   CLAUDISH_MODE      append|replace display strategy (default append)
+#   CLAUDISH_PROMPT_FILE <path>       file holding a replacement rewrite prompt
+#                                          (whole prompt, not merged; empty or
+#                                          unreadable -> built-in default)
 #   CLAUDISH_PROVIDER  ollama|anthropic|openai  which LLM serves rewrites
 #                                           (default ollama; keys, base URLs,
 #                                           and per-provider model defaults
@@ -160,7 +163,19 @@ if [ "$STUB" = "1" ]; then
   rewrite="STUB-SIMPLIFIED ✦ mode=$MODE chunks=$nparts prose_len=$prose_len ✦ (this text came from the hook, not the model)"
   dbg "stub rewrite"
 else
+  # Base system prompt, replaceable via CLAUDISH_PROMPT_FILE (a file holding the
+  # whole prompt). An unset/empty/unreadable file falls back to this default, so
+  # a bad path never stops rewrites — it just uses the built-in prompt.
   sys="You rewrite the assistant's message into much simpler, plain English. Keep every fact, name, number, and file path. Use short sentences and everyday words. Leave fenced code blocks unchanged. Output ONLY the rewritten message with no preamble, labels, or commentary."
+  if [ -n "${CLAUDISH_PROMPT_FILE:-}" ]; then
+    _p=""
+    [ -r "$CLAUDISH_PROMPT_FILE" ] && _p="$(cat "$CLAUDISH_PROMPT_FILE" 2>/dev/null)"
+    if [ -n "$_p" ]; then
+      sys="$_p"
+    else
+      dbg "CLAUDISH_PROMPT_FILE set but empty/unreadable ($CLAUDISH_PROMPT_FILE); using default prompt"
+    fi
+  fi
 
   # Context only: the original user question the assistant is answering.
   # Truncated to 800 codepoints inside jq (safe on multibyte boundaries).


### PR DESCRIPTION
Adds an optional way to replace each hook's built-in system prompt with your own, read from a file:

- `CLAUDISH_PROMPT_FILE` — display hook (`rewrite.sh`)
- `CLAUDISH_MD_PROMPT_FILE` — Markdown hook (`rewrite-md.sh`)

The file's contents replace the built-in prompt wholesale. Unset, empty, or unreadable → built-in default, so a bad path never stops rewrites. Defaults unchanged.

Also bumps the version to `0.3.0` and adds a `CHANGELOG.md` (Keep a Changelog).

🤖 Generated with [Claude Code](https://claude.com/claude-code)