### PR TITLE
Follow the session's language instead of hard-coding English

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claudish-to-english",
   "description": "Shows a plain-English rewrite of each Claude Code assistant message, produced by a local LLM (ollama, default), the Anthropic API, or any OpenAI-compatible API. Display-only: Claude's reasoning and the transcript keep the original text.",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "author": {
     "name": "Mike Gvozdev",
     "email": "mv.gvozdev@gmail.com",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - 2026-08-14
+
+### Added
+- Output language. A rewrite can be pinned to a language with `CLAUDISH_LANG`,
+  or with the `language` key in `.claude/settings*.json` — the same key Claude
+  Code answers in, read in the same order of precedence (`lang.sh`). The
+  on-screen label then names it: `💬 In plain Esperanto:`. An empty
+  `CLAUDISH_LANG` ignores the settings key; `English` forces English.
+
+### Changed
+- The built-in prompts no longer hard-code English. They ask for plain
+  language in the language the input is already written in, so an Esperanto
+  session gets an Esperanto rewrite instead of an English one. Set
+  `CLAUDISH_LANG=English` to keep the previous behaviour. A prompt supplied
+  through `CLAUDISH_PROMPT_FILE` / `CLAUDISH_MD_PROMPT_FILE` is unaffected: it
+  still replaces the whole prompt.
+- With no language configured, the display label reads `💬 In plain language:`
+  rather than `💬 In plain English:`, which it can no longer promise.
+
 ## [0.3.0] - 2026-08-13
 
 ### Added
@@ -56,6 +75,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Optional `PostToolUse` Markdown-file rewrite hook (`rewrite-md.sh`), opt-in by
   directory (`CLAUDISH_MD_DIR`), with `sibling` and `overwrite` modes.
 
+[0.4.0]: https://github.com/gvzdv/claudish-to-english/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/gvzdv/claudish-to-english/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/gvzdv/claudish-to-english/compare/v0.1.1...v0.2.0
 [0.1.1]: https://github.com/gvzdv/claudish-to-english/compare/v0.1.0...v0.1.1

--- a/README.md
+++ b/README.md
@@ -13,8 +13,12 @@ API**, or any **OpenAI-compatible API**. It is **display-only**:
 Claude's own reasoning and the saved transcript keep the original text — only
 what you read on screen changes.
 
-An optional second hook rewrites **Markdown files** into plain English when they
-are written or edited (opt-in, off by default).
+If your session speaks something other than English, so does the rewrite: it
+follows the message's own language, or the `language` setting Claude Code
+already answers in. See [Output language](#output-language).
+
+An optional second hook rewrites **Markdown files** into plain language when
+they are written or edited (opt-in, off by default).
 
 > Status: working prototype. Every hook fails **open** — if anything goes wrong
 > (provider down, timeout, missing key or dependency), you simply see Claude's
@@ -199,10 +203,47 @@ To confirm the hook is firing, set `CLAUDISH_DEBUG=1` and watch
 
 ---
 
+## Output language
+
+The rewrite comes back in the **same language as the text it rewrites**. An
+Esperanto answer is simplified into Esperanto, an English one into English;
+nothing is translated unless you ask for it.
+
+To pin a language, set one. The hooks read the same `language` key Claude Code
+itself answers in, in the same order of precedence, so a session that already
+speaks Esperanto needs no extra configuration:
+
+| Source | Example |
+|---|---|
+| `CLAUDISH_LANG` (env) | `"CLAUDISH_LANG": "Esperanto"` |
+| `<project>/.claude/settings.local.json` | `"language": "Esperanto"` |
+| `<project>/.claude/settings.json` | `"language": "Esperanto"` |
+| `~/.claude/settings.json` | `"language": "Esperanto"` |
+
+The first one that is set wins, and the on-screen label then names it:
+`💬 In plain Esperanto:`. `CLAUDISH_LANG` set but **empty** ignores the settings
+key and goes back to following the input's language; set it to `English` to
+force English on a non-English session.
+
+A configured language is appended to the built-in prompt. A prompt supplied
+through `CLAUDISH_PROMPT_FILE` or `CLAUDISH_MD_PROMPT_FILE` replaces the whole
+prompt, language line included — that file is your prompt in full, and it
+states its own language (see below).
+
+An unreadable, malformed, or non-string setting is ignored the way every other
+failure here is: rewrites keep working, in the input's language.
+
+One caveat: a rewrite is only as good as the model that writes it, and small
+local models simplify English noticeably better than they simplify anything
+else. If non-English results disappoint, try a larger model or a cloud provider
+(see [Providers](#providers)).
+
+---
+
 ## Customizing the rewrite prompt
 
 Each hook ships with a default system prompt that asks the model for plain
-English while preserving facts, code, and structure. You can **replace** either
+language while preserving facts, code, and structure. You can **replace** either
 prompt with your own to add specific rules or use wording that works
 better with your model. To do so, point the hook at a file that holds
 the prompt:
@@ -261,7 +302,7 @@ rewrites the assistant's message.
 
 | `CLAUDISH_MODE` | On screen | Notes |
 |---|---|---|
-| `append` (default) | Original streams normally, then a `💬 In plain English:` block is appended. | Safest. No streaming loss; if the LLM fails you just don't get the extra block. |
+| `append` (default) | Original streams normally, then a `💬 In plain language:` block is appended (`💬 In plain Esperanto:` when a language is configured). | Safest. No streaming loss; if the LLM fails you just don't get the extra block. |
 | `replace` | Only the simplified version (original chunks suppressed while streaming). | Experimental. Appears all at once after LLM latency; on failure it re-shows the full original. |
 
 ---
@@ -269,7 +310,7 @@ rewrites the assistant's message.
 ## Markdown file rewrite (optional second hook)
 
 A `PostToolUse` hook (`rewrite-md.sh`) rewrites Markdown **files** into plain
-English when they are written or edited. Unlike the display hook, this changes
+language when they are written or edited. Unlike the display hook, this changes
 bytes on disk.
 
 **Opt-in by directory.** It does nothing unless `CLAUDISH_MD_DIR` is set, and it
@@ -391,6 +432,7 @@ Notes:
 | `CLAUDISH_OFF_FILE` | `~/.claude/claudish-off` | Runtime kill switch. While this file exists, rewrites pause — re-checked every message, so unlike env vars it works mid-session. See [Toggling mid-session](#toggling-mid-session). |
 | `CLAUDISH_MODE` | `append` | `append` or `replace` (display hook). |
 | `CLAUDISH_PROMPT_FILE` | *(unset)* | Path to a file whose contents replace the display hook's system prompt (whole prompt, not merged). Empty/unreadable falls back to the built-in default. See [Customizing the rewrite prompt](#customizing-the-rewrite-prompt). |
+| `CLAUDISH_LANG` | *(unset)* | Language to rewrite into, e.g. `Esperanto`. Unset falls back to the `language` key in `.claude/settings*.json`; with neither set, the rewrite keeps the input's language. Empty ignores the settings key; `English` forces English. See [Output language](#output-language). |
 | `CLAUDISH_PROVIDER` | `ollama` | `ollama`, `anthropic`, or `openai` — which LLM serves rewrites (both hooks). |
 | `CLAUDISH_MODEL` | *(per provider)* | Model name; overrides the provider default (see [Providers](#providers)). The ollama default `gemma4:26b-mlx` is MLX (Apple-silicon only; Windows users must override). |
 | `CLAUDISH_OLLAMA` | `http://localhost:11434` | ollama base URL. |
@@ -473,6 +515,7 @@ claudish-to-english/
 ├── rewrite.sh              # display-rewrite hook
 ├── rewrite-md.sh           # markdown-file rewrite hook (opt-in)
 ├── providers.sh            # provider layer (ollama/anthropic/openai), sourced by both hooks
+├── lang.sh                 # output-language resolver (env + .claude/settings*.json), sourced by both hooks
 ├── CHANGELOG.md            # notable changes per version (Keep a Changelog)
 ├── LICENSE
 └── README.md

--- a/lang.sh
+++ b/lang.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# ---------------------------------------------------------------------------
+# Output-language resolver for claudish-to-english. Sourced by rewrite.sh and
+# rewrite-md.sh — not executed directly.
+#
+# claudish_language [CWD] prints the language the rewrite should be written in,
+# or nothing at all — and nothing means "no language was configured", which
+# leaves the rewrite in whatever language the text it rewrites is already
+# written in. English is not a default here, only one possible answer.
+# First non-empty source wins:
+#   1. CLAUDISH_LANG                      explicit override. Set but EMPTY
+#                                         ignores the settings below and keeps
+#                                         the text's own language; set it to
+#                                         "English" to actually force English.
+#   2. <cwd>/.claude/settings.local.json  .language
+#   3. <cwd>/.claude/settings.json        .language
+#   4. ~/.claude/settings.json            .language
+#
+# 2-4 read the same `language` key Claude Code itself reads to build the
+# "# Language" block of its system prompt, in the same precedence order. So a
+# session already answering in one language gets its rewrite in that language,
+# with nothing extra to configure.
+#
+# The value is normalized to at most three words and 30 codepoints, because it
+# lands in a system prompt and in an on-screen label — and a project's
+# .claude/settings.json travels with the repository, so it is not necessarily
+# the local user's own text. A language name fits ("Esperanto", "简体中文",
+# "Brazilian Portuguese"); a paragraph of smuggled instructions does not.
+# Every failure — no jq, unreadable or malformed JSON, missing or non-string
+# key — comes back as an empty string, never an error: an unusable setting must
+# leave rewrites working, in English.
+# ---------------------------------------------------------------------------
+
+# Collapse whitespace, trim, keep at most 3 words / 30 codepoints (jq slices by
+# codepoint, so multibyte names survive). Empty in -> empty out.
+_claudish_lang_clean() {
+  [ -n "$1" ] || return 0
+  jq -jn --arg v "$1" \
+    '$v | gsub("\\s+"; " ") | ltrimstr(" ") | rtrimstr(" ")
+        | [splits(" ")][0:3] | join(" ") | .[0:30]' 2>/dev/null
+  return 0
+}
+
+claudish_language() {
+  # An explicitly set CLAUDISH_LANG always wins, including an explicitly EMPTY
+  # one — the escape hatch for keeping rewrites in English on a session that
+  # speaks something else.
+  if [ -n "${CLAUDISH_LANG+x}" ]; then
+    _claudish_lang_clean "$CLAUDISH_LANG"
+    return 0
+  fi
+
+  _cl_cwd="${1:-$PWD}"
+  for _cl_f in "$_cl_cwd/.claude/settings.local.json" \
+               "$_cl_cwd/.claude/settings.json" \
+               "${HOME:-}/.claude/settings.json"; do
+    [ -r "$_cl_f" ] || continue
+    # Guard the type: a `language` that is not a string (null, number, object)
+    # must read as "unset", not as its jq stringification.
+    _cl_v="$(jq -r 'if (.language | type) == "string" then .language else empty end' \
+             "$_cl_f" 2>/dev/null)"
+    _cl_v="$(_claudish_lang_clean "$_cl_v")"
+    if [ -n "$_cl_v" ]; then printf '%s' "$_cl_v"; return 0; fi
+  done
+  return 0
+}

--- a/rewrite-md.sh
+++ b/rewrite-md.sh
@@ -36,6 +36,14 @@
 #   CLAUDISH_MD_PROMPT_FILE <path>    file holding a replacement Markdown prompt
 #                                     (whole prompt, not merged; empty or
 #                                     unreadable -> built-in default)
+#   CLAUDISH_LANG      <language>     language to rewrite into, e.g. "Esperanto".
+#                                     Unset falls back to the session's `language`
+#                                     setting from .claude/settings*.json (the same
+#                                     key Claude Code answers in); with neither set,
+#                                     the rewrite keeps the language of the file it
+#                                     rewrites. Set it EMPTY to ignore the settings
+#                                     key, or to "English" to force English.
+#                                     See lang.sh
 #   CLAUDISH_PROVIDER  ollama|anthropic|openai  which LLM serves rewrites (default
 #                                     ollama; keys, base URLs, and per-provider model
 #                                     defaults are documented in providers.sh)
@@ -77,9 +85,17 @@ dbg() { [ "$DEBUG" = "1" ] && printf '%s [%s] %s\n' "$(date '+%H:%M:%S')" "$$" "
 # Fail-open: leave the file as the agent wrote it.
 pass_through() { dbg "pass_through: ${1:-}"; exit 0; }
 
+SELF_DIR="$(cd "$(dirname "$0")" && pwd)"
+
 # Provider layer (ollama/anthropic/openai): MODEL/OLLAMA defaults,
 # llm_complete, llm_notice_why. Missing file -> fail open.
-. "$(cd "$(dirname "$0")" && pwd)/providers.sh" 2>/dev/null || pass_through "no providers.sh"
+. "$SELF_DIR/providers.sh" 2>/dev/null || pass_through "no providers.sh"
+
+# Output-language resolver (lang.sh). Defined here first so a missing file
+# degrades to "no configured language" — the rewrite then keeps the file's own
+# language — instead of stopping rewrites.
+claudish_language() { :; }
+. "$SELF_DIR/lang.sh" 2>/dev/null || dbg "no lang.sh; keeping the file's language"
 
 # Print the canonical absolute path of $1 (its parent directory must exist).
 # Runs in a subshell so the cd never leaks.
@@ -163,6 +179,12 @@ prose_len="$(printf '%s' "$body" \
 dbg "prose_len=$prose_len min=$MIN_CHARS fm_lines=${fm_lines:-0}"
 [ "${prose_len:-0}" -ge "$MIN_CHARS" ] || pass_through "below min_chars"
 
+# ---- output language ------------------------------------------------------
+# Resolved after the cheap gates, since it reads settings files. Empty -> the
+# rewrite keeps the language the file is already written in.
+OUT_LANG="$(claudish_language "$CWD")"
+dbg "language=${OUT_LANG:-same as the file (default)}"
+
 # ---- obtain the rewrite ---------------------------------------------------
 rewrite=""
 curl_rc=0
@@ -173,7 +195,15 @@ if [ "$STUB" = "1" ]; then
 else
   # Base system prompt, replaceable via CLAUDISH_MD_PROMPT_FILE (a file holding
   # the whole prompt). An unset/empty/unreadable file falls back to this default.
-  sys="You rewrite Markdown prose into much simpler, plain English. Keep every fact, name, number, link, and file path. Keep all Markdown structure — headings, lists, tables, and links. Do NOT change fenced code blocks or any YAML frontmatter; reproduce them exactly. Use short sentences and everyday words. Output ONLY the rewritten Markdown, with no preamble, labels, or commentary."
+  sys="You rewrite Markdown prose into much simpler, plain language. Write the rewrite in the same language as the file you are rewriting. Keep every fact, name, number, link, and file path. Keep all Markdown structure — headings, lists, tables, and links. Do NOT change fenced code blocks or any YAML frontmatter; reproduce them exactly. Use short sentences and everyday words. Output ONLY the rewritten Markdown, with no preamble, labels, or commentary."
+  # A configured language overrides "same language as the file" — it is the last
+  # word in the prompt, and it names the language explicitly. The line goes on
+  # BEFORE the prompt-file check on purpose: a usable CLAUDISH_MD_PROMPT_FILE
+  # replaces the whole prompt, this line included. That file is the user's
+  # prompt in full, and it states its own language.
+  if [ -n "$OUT_LANG" ]; then
+    sys="$sys"$'\n\n'"Write the rewritten Markdown in $OUT_LANG instead, whatever language the original is in. Use $OUT_LANG for all prose, including headings, list items, and table cells. Keep code, identifiers, file paths, link targets, and YAML frontmatter exactly as they are."
+  fi
   if [ -n "${CLAUDISH_MD_PROMPT_FILE:-}" ]; then
     _p=""
     [ -r "$CLAUDISH_MD_PROMPT_FILE" ] && _p="$(cat "$CLAUDISH_MD_PROMPT_FILE" 2>/dev/null)"

--- a/rewrite.sh
+++ b/rewrite.sh
@@ -34,6 +34,16 @@
 #   CLAUDISH_PROMPT_FILE <path>       file holding a replacement rewrite prompt
 #                                          (whole prompt, not merged; empty or
 #                                          unreadable -> built-in default)
+#   CLAUDISH_LANG      <language>     language to rewrite into, e.g. "Esperanto".
+#                                          Unset falls back to the session's
+#                                          `language` setting from
+#                                          .claude/settings*.json (the same key
+#                                          Claude Code answers in); with neither
+#                                          set, the rewrite simply keeps the
+#                                          language of the message it rewrites.
+#                                          Set it EMPTY to ignore the settings
+#                                          key, or to "English" to force
+#                                          English. See lang.sh
 #   CLAUDISH_PROVIDER  ollama|anthropic|openai  which LLM serves rewrites
 #                                           (default ollama; keys, base URLs,
 #                                           and per-provider model defaults
@@ -66,7 +76,8 @@ DEBUG="${CLAUDISH_DEBUG:-0}"
 NOTICE="${CLAUDISH_NOTICE:-1}"
 
 BUF_ROOT="${TMPDIR:-/tmp}/claudish-to-english"
-SEP=$'\n\n────────────────────────\n💬 In plain English:\n\n'
+# SEP (the on-screen label above the rewrite) names the configured output
+# language, so it is built on the final chunk, once that language is known.
 
 mkdir -p "$BUF_ROOT" 2>/dev/null || true
 
@@ -75,9 +86,17 @@ dbg() { [ "$DEBUG" = "1" ] && printf '%s [%s] %s\n' "$(date '+%H:%M:%S')" "$$" "
 # Fail-open: keep the original delta on screen.
 pass_through() { dbg "pass_through"; exit 0; }
 
+SELF_DIR="$(cd "$(dirname "$0")" && pwd)"
+
 # Provider layer (ollama/anthropic/openai): MODEL/OLLAMA defaults,
 # llm_complete, llm_notice_why. Missing file -> fail open.
-. "$(cd "$(dirname "$0")" && pwd)/providers.sh" 2>/dev/null || pass_through
+. "$SELF_DIR/providers.sh" 2>/dev/null || pass_through
+
+# Output-language resolver (lang.sh). Defined here first so a missing file
+# degrades to "no configured language" — the rewrite then keeps the message's
+# own language — instead of stopping rewrites.
+claudish_language() { :; }
+. "$SELF_DIR/lang.sh" 2>/dev/null || dbg "no lang.sh; keeping the message's language"
 
 # Replace this chunk's on-screen text with $1 (a temp file, read and then
 # removed here — the opportunistic find below only sweeps buffer DIRECTORIES,
@@ -108,6 +127,11 @@ sid="$(printf '%s' "$payload"   | jq -r '.session_id // "nosession"' 2>/dev/null
 idx="$(printf '%s' "$payload"   | jq -r '(.index // 0) | tostring' 2>/dev/null)"
 final="$(printf '%s' "$payload" | jq -r '.final // false' 2>/dev/null)"
 tpath="$(printf '%s' "$payload" | jq -r '.transcript_path // empty' 2>/dev/null)"
+# Only used to find project-level .claude/settings*.json; the hook already runs
+# in the session's directory, so $PWD is a fine fallback when the event carries
+# no cwd of its own.
+cwd="$(printf '%s' "$payload"   | jq -r '.cwd // empty' 2>/dev/null)"
+[ -d "$cwd" ] || cwd="$PWD"
 [ -n "$mid" ] || pass_through
 case "$idx" in ''|*[!0-9]*) idx=0 ;; esac
 
@@ -154,6 +178,14 @@ if [ "${prose_len:-0}" -lt "$MIN_CHARS" ]; then
   pass_through
 fi
 
+# ---- output language ------------------------------------------------------
+# Resolved on the final chunk only: it reads settings files, and nothing before
+# here needs it. Empty -> the rewrite follows the language of the message, so
+# the label must not claim one either.
+OUT_LANG="$(claudish_language "$cwd")"
+SEP=$'\n\n────────────────────────\n💬 In plain '"${OUT_LANG:-language}"$':\n\n'
+dbg "language=${OUT_LANG:-same as the message (default)}"
+
 # ---- obtain the rewrite --------------------------------------------------
 rewrite=""
 curl_rc=0
@@ -166,7 +198,15 @@ else
   # Base system prompt, replaceable via CLAUDISH_PROMPT_FILE (a file holding the
   # whole prompt). An unset/empty/unreadable file falls back to this default, so
   # a bad path never stops rewrites — it just uses the built-in prompt.
-  sys="You rewrite the assistant's message into much simpler, plain English. Keep every fact, name, number, and file path. Use short sentences and everyday words. Leave fenced code blocks unchanged. Output ONLY the rewritten message with no preamble, labels, or commentary."
+  sys="You rewrite the assistant's message into much simpler, plain language. Write the rewrite in the same language as the message you are rewriting. Keep every fact, name, number, and file path. Use short sentences and everyday words. Leave fenced code blocks unchanged. Output ONLY the rewritten message with no preamble, labels, or commentary."
+  # A configured language overrides "same language as the message" — it is the
+  # last word in the prompt, and it names the language explicitly. The line goes
+  # on BEFORE the prompt-file check on purpose: a usable CLAUDISH_PROMPT_FILE
+  # replaces the whole prompt, this line included. That file is the user's
+  # prompt in full, and it states its own language.
+  if [ -n "$OUT_LANG" ]; then
+    sys="$sys"$'\n\n'"Write the rewrite in $OUT_LANG instead, whatever language the assistant's message is in. Use $OUT_LANG for all prose, including headings and lists. Keep code, identifiers, file paths, commands, and quoted output exactly as they are."
+  fi
   if [ -n "${CLAUDISH_PROMPT_FILE:-}" ]; then
     _p=""
     [ -r "$CLAUDISH_PROMPT_FILE" ] && _p="$(cat "$CLAUDISH_PROMPT_FILE" 2>/dev/null)"


### PR DESCRIPTION
Rewrites now follow the language of the session instead of always producing
English. If `language` is set in `.claude/settings.json` — the same key Claude
Code itself answers in — the rewrite uses it; otherwise it keeps the language
of the message it rewrites. `CLAUDISH_LANG` overrides both, and
`CLAUDISH_LANG=English` restores the previous behaviour.

So an English answer on a session that speaks Esperanto now reads:

```
────────────────────────
💬 In plain Esperanto:

La funkcio konservas ĉiun pecon de la fluo sur la disko. Ĝi vokas la modelon
nur kiam la tuta mesaĝo estas finita. Tial vi rimarkas malfruon nur unufoje
por ĉiu mesaĝo, ne por ĉiu peco.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
