### PR TITLE
Add a codex CLI provider

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claudish-to-english",
   "description": "Shows a plain-language rewrite of each Claude Code assistant message, produced by a local LLM (ollama, default), the Anthropic API, or any OpenAI-compatible API. Switch it on the fly with /claudish (on/off, append/replace, language, model). Display-only: Claude's reasoning and the transcript keep the original text.",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "author": {
     "name": "Mike Gvozdev",
     "email": "mv.gvozdev@gmail.com",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.0] - 2026-08-20
+
+### Added
+- A **`codex` provider** (`CLAUDISH_PROVIDER=codex`) that runs the rewrite
+  through the OpenAI codex CLI non-interactively (`codex exec`, `--sandbox
+  read-only`, `--skip-git-repo-check`, outside any repo). It uses the CLI's own
+  login, so there is **no API key and no local model server** — a third keyless
+  path alongside ollama. `CLAUDISH_MODEL` maps to `codex -m`; unset uses the
+  CLI's configured default. A new `CLAUDISH_CODEX_EFFORT` maps to
+  `-c model_reasoning_effort=<value>`, overriding the CLI's reasoning effort for
+  the per-message rewrite only (e.g. `low` keeps it fast even when the CLI's
+  coding default is a high-effort tier). The call is bounded by a background
+  poll-and-kill loop (stock macOS has no `timeout(1)`), reads the final message
+  from `codex exec -o`, and fails open like every other provider — a missing
+  CLI, a non-zero exit, or a timeout just leaves the original text plus the
+  once-per-session notice. Contributed by
+  [@datvo06](https://github.com/datvo06) in
+  [PR #15](https://github.com/gvzdv/claudish-to-english/pull/15).
+
 ## [0.5.1] - 2026-08-20
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
 </p>
 
 A Claude Code plugin that shows a **plain-English rewrite** of each assistant
-message, produced by a **local LLM via ollama** (default), the **Anthropic
-API**, or any **OpenAI-compatible API**. It is **display-only**:
+message, produced by a **local LLM via ollama** (default), the **codex CLI**,
+the **Anthropic API**, or any **OpenAI-compatible API**. It is **display-only**:
 Claude's own reasoning and the saved transcript keep the original text — only
 what you read on screen changes.
 
@@ -309,6 +309,15 @@ frontmatter, so the frontmatter stays on line 1 where parsers expect it.
 ---
 
 ## Providers
+
+### codex
+
+`CLAUDISH_PROVIDER=codex` runs the rewrite through the OpenAI codex CLI
+(`codex exec`, read-only sandbox, outside any repo), using the CLI's own
+login. No API key and no local model server. `CLAUDISH_MODEL` overrides
+the CLI's configured model; unset uses the CLI default. Requires `codex`
+on PATH; fails open like every other provider.
+
 
 Rewrites go through one of three providers, selected with `CLAUDISH_PROVIDER`
 (both hooks share the setting). The default is unchanged from upstream: local

--- a/README.md
+++ b/README.md
@@ -423,24 +423,26 @@ frontmatter, so the frontmatter stays on line 1 where parsers expect it.
 
 ## Providers
 
-### codex
-
-`CLAUDISH_PROVIDER=codex` runs the rewrite through the OpenAI codex CLI
-(`codex exec`, read-only sandbox, outside any repo), using the CLI's own
-login. No API key and no local model server. `CLAUDISH_MODEL` overrides
-the CLI's configured model; unset uses the CLI default. Requires `codex`
-on PATH; fails open like every other provider.
-
-
-Rewrites go through one of three providers, selected with `CLAUDISH_PROVIDER`
+Rewrites go through one of four providers, selected with `CLAUDISH_PROVIDER`
 (both hooks share the setting). The default is unchanged from upstream: local
 ollama, nothing leaves your machine.
 
 | Provider | Endpoint | Key | Default model |
 |---|---|---|---|
 | `ollama` (default) | `CLAUDISH_OLLAMA` (`http://localhost:11434`) | none | `gemma4:26b-mlx` |
+| `codex` | OpenAI codex CLI (`codex exec`) — uses the CLI's own login | none | *(CLI default)* |
 | `anthropic` | `CLAUDISH_ANTHROPIC_URL` (`https://api.anthropic.com`) + `/v1/messages` | `CLAUDISH_ANTHROPIC_KEY` or `ANTHROPIC_API_KEY` | `claude-haiku-4-5` |
 | `openai` | `CLAUDISH_OPENAI_URL` + `/chat/completions` | `CLAUDISH_OPENAI_KEY` or `OPENAI_API_KEY` | `gpt-5.6-luna` |
+
+### codex
+
+`CLAUDISH_PROVIDER=codex` runs the rewrite through the OpenAI codex CLI
+(`codex exec`, read-only sandbox, outside any repo), using the CLI's own
+login. No API key and no local model server. `CLAUDISH_MODEL` overrides
+the CLI's configured model; unset uses the CLI default. `CLAUDISH_CODEX_EFFORT`
+overrides the CLI's reasoning effort for the rewrite only (e.g. `low` keeps a
+per-message rewrite fast even when the CLI's coding default is a high-effort
+tier). Requires `codex` on PATH; fails open like every other provider.
 
 > [!CAUTION]
 > The cloud providers pick their key up from the **ambient environment**
@@ -490,8 +492,9 @@ Notes:
   api.openai.com — needed for models that reject `reasoning_effort` entirely.
 - The anthropic provider caps completions at `CLAUDISH_MAX_TOKENS` (default
   4096, since the Messages API requires an explicit cap).
-- A rewrite that hits an output-token cap is **discarded**, not shown — on all
-  three providers (ollama's `done_reason: "length"` included): a half-finished
+- A rewrite that hits an output-token cap is **discarded**, not shown — on the
+  ollama, anthropic, and openai providers (ollama's `done_reason: "length"`
+  included): a half-finished
   rewrite on screen is confusing, and in the Markdown hook's `overwrite` mode
   it would replace your real document. You get the original text plus the
   once-per-session notice suggesting a higher cap.
@@ -518,7 +521,7 @@ Notes:
 | `CLAUDISH_PROMPT_FILE` | *(unset)* | Path to a file whose contents replace the display hook's system prompt (whole prompt, not merged). Empty/unreadable falls back to the built-in default. See [Customizing the rewrite prompt](#customizing-the-rewrite-prompt). |
 | `CLAUDISH_LANG` | *(unset)* | Language to rewrite into, e.g. `Esperanto`. Unset falls back to the `language` key in `.claude/settings*.json`; with neither set, the rewrite keeps the input's language. Empty ignores the settings key; `English` forces English. See [Output language](#output-language). |
 | `CLAUDISH_LANG_FILE` | `~/.claude/claudish-lang` | Runtime language override: a language name in this file wins over `CLAUDISH_LANG` and the settings key, re-checked every message. Written by `/claudish language <name>`. See [Controlling it live](#controlling-it-live-claudish). |
-| `CLAUDISH_PROVIDER` | `ollama` | `ollama`, `anthropic`, or `openai` — which LLM serves rewrites (both hooks). |
+| `CLAUDISH_PROVIDER` | `ollama` | `ollama`, `codex`, `anthropic`, or `openai` — which LLM serves rewrites (both hooks). |
 | `CLAUDISH_MODEL` | *(per provider)* | Model name; overrides the provider default (see [Providers](#providers)). The ollama default `gemma4:26b-mlx` is MLX (Apple-silicon only; Windows users must override). |
 | `CLAUDISH_MODEL_FILE` | `~/.claude/claudish-model` | Runtime model override: a model name in this file wins over `CLAUDISH_MODEL`, re-checked every message (applies to whatever provider is configured). Written by `/claudish model <name>`. See [Controlling it live](#controlling-it-live-claudish). |
 | `CLAUDISH_OLLAMA` | `http://localhost:11434` | ollama base URL. |
@@ -527,6 +530,7 @@ Notes:
 | `CLAUDISH_OPENAI_URL` | `https://api.openai.com/v1` | Base URL for any OpenAI-compatible endpoint (LM Studio, llama.cpp server, vLLM, OpenRouter, ...). Trailing slashes are ignored. |
 | `CLAUDISH_ANTHROPIC_URL` | `https://api.anthropic.com` | Base URL for the anthropic provider — override for proxies/gateways that speak the Messages API. |
 | `CLAUDISH_OPENAI_EFFORT` | `none` on api.openai.com, else *(unset)* | `reasoning_effort` sent with openai-provider requests. Set explicitly empty to omit the field. |
+| `CLAUDISH_CODEX_EFFORT` | *(unset)* | `model_reasoning_effort` for the codex provider (e.g. `low`). Unset uses the codex CLI's configured effort. Applies to the rewrite only. |
 | `CLAUDISH_MAX_TOKENS` | `4096` | Completion cap for the anthropic provider. Rewrites that hit the cap are discarded (fail-open), with a notice to raise it. |
 | `CLAUDISH_MIN_CHARS` | `200` | Skip messages/files whose prose (code stripped) is shorter than this. |
 | `CLAUDISH_STUB` | `0` | `1` = deterministic stub instead of the model (for testing display mechanics). |

--- a/providers.sh
+++ b/providers.sh
@@ -41,6 +41,9 @@
 #                           (CLAUDISH_OPENAI_EFFORT=) to force the field off
 #                           even for api.openai.com — needed for models that
 #                           reject reasoning_effort entirely.
+#   CLAUDISH_CODEX_EFFORT   model_reasoning_effort for the codex provider (e.g.
+#                           "low"). Unset uses the codex CLI's configured
+#                           effort. Applies to the rewrite only.
 #
 # The caller must define dbg() and set LLM_TIMEOUT before calling
 # llm_complete, and may set TIMEOUT_HINT to customize llm_notice_why's

--- a/providers.sh
+++ b/providers.sh
@@ -17,6 +17,9 @@
 #
 # Providers (CLAUDISH_PROVIDER):
 #   ollama     (default) local ollama at CLAUDISH_OLLAMA
+#   codex      the OpenAI codex CLI, non-interactively (codex exec); uses the
+#              CLI's own login, so no API key and no local model server. The
+#              rewrite runs with --sandbox read-only outside any repo.
 #   anthropic  Anthropic Messages API; key from CLAUDISH_ANTHROPIC_KEY or
 #              ANTHROPIC_API_KEY; base URL from CLAUDISH_ANTHROPIC_URL
 #   openai     any OpenAI-compatible /chat/completions endpoint (OpenAI,
@@ -73,6 +76,7 @@ fi
 case "$PROVIDER" in
   anthropic) MODEL="${CLAUDISH_MODEL:-claude-haiku-4-5}" ;;
   openai)    MODEL="${CLAUDISH_MODEL:-gpt-5.6-luna}" ;;
+  codex)     MODEL="${CLAUDISH_MODEL:-}" ;;  # empty = the codex CLI's configured default
   *)         MODEL="${CLAUDISH_MODEL:-gemma4:26b-mlx}" ;;
 esac
 
@@ -171,6 +175,40 @@ llm_complete() {
       finish="$(printf '%s' "$resp" | jq -r '.choices[0].finish_reason // empty' 2>/dev/null)"
       [ "$finish" = "length" ] && { truncated=1; rewrite=""; }
       ;;
+    codex)
+      if ! command -v codex >/dev/null 2>&1; then
+        dbg "codex: CLI not found"; curl_rc=1; return 0
+      fi
+      _out="$(mktemp "${TMPDIR:-/tmp}/claudish-codex-out.XXXXXX" 2>/dev/null)" || return 2
+      _errf="$(mktemp "${TMPDIR:-/tmp}/claudish-codex-err.XXXXXX" 2>/dev/null)" || { rm -f "$_out"; return 2; }
+      trap 'rm -f "$_out" "$_errf" 2>/dev/null' EXIT
+      # codex has no separate system channel; prepend the system prompt.
+      # No timeout(1) on stock macOS, so background the call and kill on expiry.
+      codex exec --sandbox read-only --skip-git-repo-check -C "${TMPDIR:-/tmp}" \
+        ${MODEL:+-m "$MODEL"} -o "$_out" "$_sys
+
+$_user" >/dev/null 2>"$_errf" &
+      _pid=$!
+      _t=0
+      while kill -0 "$_pid" 2>/dev/null; do
+        if [ "$_t" -ge "$LLM_TIMEOUT" ]; then
+          kill -TERM "$_pid" 2>/dev/null; wait "$_pid" 2>/dev/null
+          curl_rc=28
+          rm -f "$_out" "$_errf" 2>/dev/null
+          dbg "codex timed out after ${LLM_TIMEOUT}s"
+          return 0
+        fi
+        sleep 1; _t=$((_t + 1))
+      done
+      wait "$_pid"; _rc=$?
+      rewrite="$(cat "$_out" 2>/dev/null)"
+      if [ "$_rc" != "0" ]; then
+        err="$(tail -c 400 "$_errf" 2>/dev/null)"
+        err="${err:-codex exec failed with exit $_rc}"
+        rewrite=""
+      fi
+      rm -f "$_out" "$_errf" 2>/dev/null
+      ;;
     *)
       req="$(jq -n --arg m "$MODEL" --arg s "$_sys" --arg u "$_user" \
             '{model:$m,stream:false,think:false,options:{temperature:0.3},messages:[{role:"system",content:$s},{role:"user",content:$u}]}' 2>/dev/null)"
@@ -241,6 +279,15 @@ llm_notice_why() {
         NOTICE_WHY="the rewrite timed out after ${LLM_TIMEOUT}s — ${TIMEOUT_HINT:-raise the timeout}"
       elif [ "$curl_rc" != "0" ]; then
         NOTICE_WHY="cannot reach ${OPENAI_URL} (curl exit $curl_rc)"
+      fi
+      ;;
+    codex)
+      if ! command -v codex >/dev/null 2>&1; then
+        NOTICE_WHY="the codex CLI is not on PATH (install it or pick another CLAUDISH_PROVIDER), so rewrites are off"
+      elif [ "$curl_rc" = "28" ]; then
+        NOTICE_WHY="the rewrite timed out after ${LLM_TIMEOUT}s — ${TIMEOUT_HINT:-raise the timeout}"
+      elif [ -n "${err:-}" ]; then
+        NOTICE_WHY="codex error: ${err}"
       fi
       ;;
     *)

--- a/providers.sh
+++ b/providers.sh
@@ -184,8 +184,13 @@ llm_complete() {
       trap 'rm -f "$_out" "$_errf" 2>/dev/null' EXIT
       # codex has no separate system channel; prepend the system prompt.
       # No timeout(1) on stock macOS, so background the call and kill on expiry.
+      # CLAUDISH_CODEX_EFFORT overrides the CLI's configured reasoning effort
+      # for the rewrite only ("low" keeps a per-message rewrite at seconds
+      # even when the CLI's coding default is a high-effort tier).
       codex exec --sandbox read-only --skip-git-repo-check -C "${TMPDIR:-/tmp}" \
-        ${MODEL:+-m "$MODEL"} -o "$_out" "$_sys
+        ${MODEL:+-m "$MODEL"} \
+        ${CLAUDISH_CODEX_EFFORT:+-c "model_reasoning_effort=${CLAUDISH_CODEX_EFFORT}"} \
+        -o "$_out" "$_sys
 
 $_user" >/dev/null 2>"$_errf" &
       _pid=$!


### PR DESCRIPTION
This PR adds `CLAUDISH_PROVIDER=codex`.

1. Add `codex` case to `providers.sh`
2. Also updates the README.
