### PR TITLE
docs: note a hosted version in Related

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,10 +464,10 @@ local unless you understand and accept it.
 This plugin is the original and stays local by default, so no changes are needed there.
 
 If you prefer a hosted version of the same idea, [declaude](https://github.com/tenkenco/declaude)
-is available. It uses the same approach and runs an open-weights model (Qwen2.5-14B) on its own
-GPUs, with a REST API, an MCP server, and an Ollama-compatible endpoint. It offers 100 free rewrites
-per month, $5 per month beyond that. The server source is MIT, and it credits this repository in its
-README, system prompt, and third-party notices.
+is available. It uses the same approach, runs an open-weights model on its own GPUs, and exposes a
+REST API, an MCP server, and an Ollama-compatible endpoint. Its source is MIT, and it credits this
+repository in its README, system prompt, and third-party notices. See its README for the current
+model, limits, and pricing.
 
 Since declaude speaks the Ollama API, it can also back this plugin on a machine that cannot spare
 17 GB:
@@ -476,6 +476,10 @@ Since declaude speaks the Ollama API, it can also back this plugin on a machine 
 export CLAUDISH_OLLAMA="https://x:$DECLAUDE_TOKEN@speak-english.tenken.co"
 export CLAUDISH_MODEL=qwen2.5-14b-instruct
 ```
+
+The token sits in the URL because the ollama provider sends no auth header. Notices redact
+credentials before printing (see `redact_url` in `providers.sh`), so an unreachable host shows
+`https://***@host` rather than your token.
 
 > [!NOTE]
 > Using declaude sends your assistant messages to a third-party server, similar to how the

--- a/README.md
+++ b/README.md
@@ -459,6 +459,29 @@ contents) is sent to that API. The same applies to pointing `CLAUDISH_OLLAMA`
 or `CLAUDISH_OPENAI_URL` at a remote/hosted endpoint. Don't switch away from
 local unless you understand and accept it.
 
+## Related: a hosted version
+
+This plugin is the original and stays local by default, so no changes are needed there.
+
+If you prefer a hosted version of the same idea, [declaude](https://github.com/tenkenco/declaude)
+is available. It uses the same approach and runs an open-weights model (Qwen2.5-14B) on its own
+GPUs, with a REST API, an MCP server, and an Ollama-compatible endpoint. It offers 100 free rewrites
+per month, $5 per month beyond that. The server source is MIT, and it credits this repository in its
+README, system prompt, and third-party notices.
+
+Since declaude speaks the Ollama API, it can also back this plugin on a machine that cannot spare
+17 GB:
+
+```bash
+export CLAUDISH_OLLAMA="https://x:$DECLAUDE_TOKEN@speak-english.tenken.co"
+export CLAUDISH_MODEL=qwen2.5-14b-instruct
+```
+
+> [!NOTE]
+> Using declaude sends your assistant messages to a third-party server, similar to how the
+> `anthropic` and `openai` providers operate. The default local `ollama` provider remains the only
+> setup where data does not leave your machine.
+
 ---
 
 ## Layout

--- a/README.md
+++ b/README.md
@@ -469,17 +469,16 @@ REST API, an MCP server, and an Ollama-compatible endpoint. Its source is MIT, a
 repository in its README, system prompt, and third-party notices. See its README for the current
 model, limits, and pricing.
 
-Since declaude speaks the Ollama API, it can also back this plugin on a machine that cannot spare
-17 GB:
+It speaks the OpenAI protocol, so it can also back this plugin on a machine that cannot spare
+17 GB, using the existing `openai` provider and nothing new:
 
 ```bash
-export CLAUDISH_OLLAMA="https://x:$DECLAUDE_TOKEN@speak-english.tenken.co"
-export CLAUDISH_MODEL=qwen2.5-14b-instruct
+export CLAUDISH_PROVIDER=openai
+export CLAUDISH_OPENAI_URL=https://speak-english.tenken.co/v1
+export CLAUDISH_OPENAI_KEY=$DECLAUDE_TOKEN
 ```
 
-The token sits in the URL because the ollama provider sends no auth header. Notices redact
-credentials before printing (see `redact_url` in `providers.sh`), so an unreachable host shows
-`https://***@host` rather than your token.
+The key travels in the `Authorization` header, so it never appears in a URL.
 
 > [!NOTE]
 > Using declaude sends your assistant messages to a third-party server, similar to how the

--- a/README.md
+++ b/README.md
@@ -464,10 +464,10 @@ local unless you understand and accept it.
 This plugin is the original and stays local by default, so no changes are needed there.
 
 If you prefer a hosted version of the same idea, [declaude](https://github.com/tenkenco/declaude)
-is available. It uses the same approach, runs an open-weights model on its own GPUs, and exposes a
-REST API, an MCP server, and an Ollama-compatible endpoint. Its source is MIT, and it credits this
-repository in its README, system prompt, and third-party notices. See its README for the current
-model, limits, and pricing.
+is available. It uses the same approach, runs an open-weights model on its own GPUs, and exposes
+OpenAI-compatible and Ollama-compatible endpoints as well as an MCP server. Its source is MIT, and
+it credits this repository in its README, system prompt, and third-party notices. See its README
+for the current model, limits, and pricing.
 
 It speaks the OpenAI protocol, so it can also back this plugin on a machine that cannot spare
 17 GB, using the existing `openai` provider and nothing new:
@@ -478,7 +478,8 @@ export CLAUDISH_OPENAI_URL=https://speak-english.tenken.co/v1
 export CLAUDISH_OPENAI_KEY=$DECLAUDE_TOKEN
 ```
 
-The key travels in the `Authorization` header, so it never appears in a URL.
+Tokens come from [speak-english.tenken.co/signin](https://speak-english.tenken.co/signin). The key
+travels in the `Authorization` header, so it never appears in a URL.
 
 > [!NOTE]
 > Using declaude sends your assistant messages to a third-party server, similar to how the

--- a/providers.sh
+++ b/providers.sh
@@ -46,6 +46,12 @@
 # ---------------------------------------------------------------------------
 
 PROVIDER="${CLAUDISH_PROVIDER:-ollama}"
+# A URL can carry credentials (https://user:token@host). Notices are printed on screen and
+# pasted into bug reports, so strip them before any URL is shown.
+redact_url() {
+  printf '%s' "${1:-}" | sed -E 's#(https?://)[^/@]*@#\1***@#'
+}
+
 OLLAMA="${CLAUDISH_OLLAMA:-http://localhost:11434}"
 ANTHROPIC_KEY="${CLAUDISH_ANTHROPIC_KEY:-${ANTHROPIC_API_KEY:-}}"
 OPENAI_KEY="${CLAUDISH_OPENAI_KEY:-${OPENAI_API_KEY:-}}"
@@ -240,7 +246,7 @@ llm_notice_why() {
       elif [ "$curl_rc" = "28" ]; then
         NOTICE_WHY="the rewrite timed out after ${LLM_TIMEOUT}s — ${TIMEOUT_HINT:-raise the timeout}"
       elif [ "$curl_rc" != "0" ]; then
-        NOTICE_WHY="cannot reach ${OPENAI_URL} (curl exit $curl_rc)"
+        NOTICE_WHY="cannot reach $(redact_url "$OPENAI_URL") (curl exit $curl_rc)"
       fi
       ;;
     *)
@@ -252,7 +258,7 @@ llm_notice_why() {
       elif [ "$curl_rc" = "28" ]; then
         NOTICE_WHY="the rewrite timed out after ${LLM_TIMEOUT}s (model too slow for this message) — ${TIMEOUT_HINT:-raise the timeout or set CLAUDISH_MODEL to a smaller model}"
       elif [ "$curl_rc" != "0" ]; then
-        NOTICE_WHY="can't reach ollama at $OLLAMA — start it with \`ollama serve\` (see the plugin README)"
+        NOTICE_WHY="can't reach ollama at $(redact_url "$OLLAMA") — start it with \`ollama serve\` (see the plugin README)"
       elif printf '%s' "${err:-}" | grep -qi 'not found'; then
         NOTICE_WHY="ollama model '$MODEL' isn't available — pull it with \`ollama pull $MODEL\`, or set CLAUDISH_MODEL to a model you have"
       elif [ -n "${err:-}" ]; then


### PR DESCRIPTION
Hey there — thank you for making this. I really love the results so far.

After testing locally I wanted to use a larger model, so I ended up hosting it on my GCP servers,
and it is available for other people to try out as well.

## What

Adds a short "Related: a hosted version" note near the end of the README. There are no code changes,
and the default provider remains unchanged.

## Why

People often land here, see the "pull a ~17 GB model first" requirement, and some leave without
seeing what the plugin does. Adding a pointer to a hosted version gives these users somewhere to go,
while keeping this repository as the original, local-by-default version.

I have deliberately **not** included it in the Providers table or the setup sections. It is not meant
as an alternative to configure; it is a related project that exists independently and is noted as a
footnote.

## Disclosure

That hosted service is [declaude](https://github.com/tenkenco/declaude), MIT-licensed, and I run
it — so I have an interest here. Two points to note:

- The wording is intentionally unflattering to my own service. It clearly states that text leaves
  your machine and that local ollama remains the only fully private option, consistent with your
  existing cautionary block on cloud providers.
- If you prefer not to include a hosted service link, want it worded differently, or want it placed
  elsewhere, let me know and I will adjust or close this. No hard feelings either way.

declaude started as a hosted descendant of this project and credits it in its README, system prompt,
and third-party notices.

## Test

No tests are required; this is purely a documentation change. The environment snippet is accurate:
this plugin's ollama path issues a single POST to `$OLLAMA/api/chat`, which that endpoint
implements. The fail-open behavior remains unchanged, producing the same skip and once-per-session
notice for an unreachable or unauthenticated host.