### PR TITLE
Add /claudish for runtime switching: on/off, display mode, style presets, language, and model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to this project are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- `/claudish` slash command for runtime switching (`commands/claudish.md` +
+  `claudish-ctl.sh`). `on`/`off` drive the existing off-file; every other
+  subcommand writes a `key=value` line into ONE runtime file
+  (`~/.claude/claudish-runtime`, path: `CLAUDISH_RUNTIME_FILE`) that the hooks
+  re-read on every message, so everything switches mid-session without
+  restarting: `append`/`replace` (`mode=`), `style tldr|5y|default` (`style=`),
+  `language <name>` (`language=`, cleaned by `lang.sh` like every other
+  source), `model <name>` (`model=`, sanitised in `providers.sh`, both hooks),
+  `status`, and a bare `/claudish` that cycles off → append → replace. Env
+  vars keep working as launch-time defaults; a key, while present, wins.
+- Rewrite-style presets for the display hook (`CLAUDISH_STYLE` or the runtime
+  file's `style=` key): `tldr` produces a clearly shorter summary, `5y`
+  explains like you're five; the on-screen label follows (`💬 TL;DR:`,
+  `💬 Like you're five:`). Styles replace only the built-in base prompt — the
+  output language still applies, and a usable `CLAUDISH_PROMPT_FILE` wins over
+  any style. The Markdown hook is unaffected.
+- `/claudish last` reprints the ORIGINAL text of the last assistant message
+  from the session transcript (the rewrite is display-only, so the transcript
+  always has it) — useful in `replace` mode. Such reprints start with a
+  `<!-- claudish:original -->` marker line that the display hook strips and
+  never rewrites.
+
 ## [0.4.0] - 2026-08-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -431,6 +431,8 @@ Notes:
 | `CLAUDISH_ENABLED` | `1` | Master switch. `0` = pass everything through. Read once at session start. |
 | `CLAUDISH_OFF_FILE` | `~/.claude/claudish-off` | Runtime kill switch. While this file exists, rewrites pause — re-checked every message, so unlike env vars it works mid-session. See [Toggling mid-session](#toggling-mid-session). |
 | `CLAUDISH_MODE` | `append` | `append` or `replace` (display hook). |
+| `CLAUDISH_STYLE` | *(unset)* | Rewrite-style preset for the display hook: `tldr` (clearly shorter summary) or `5y` (explain like I'm five). Unset/other = the default plain-language rewrite. A usable `CLAUDISH_PROMPT_FILE` wins over any style. |
+| `CLAUDISH_RUNTIME_FILE` | `~/.claude/claudish-runtime` | Runtime override file written by [`/claudish`](#the-claudish-command): `key=value` lines (`mode=`, `style=`, `language=`, `model=`) that win over the matching env vars while present — re-read every message. |
 | `CLAUDISH_PROMPT_FILE` | *(unset)* | Path to a file whose contents replace the display hook's system prompt (whole prompt, not merged). Empty/unreadable falls back to the built-in default. See [Customizing the rewrite prompt](#customizing-the-rewrite-prompt). |
 | `CLAUDISH_LANG` | *(unset)* | Language to rewrite into, e.g. `Esperanto`. Unset falls back to the `language` key in `.claude/settings*.json`; with neither set, the rewrite keeps the input's language. Empty ignores the settings key; `English` forces English. See [Output language](#output-language). |
 | `CLAUDISH_PROVIDER` | `ollama` | `ollama`, `anthropic`, or `openai` — which LLM serves rewrites (both hooks). |
@@ -482,6 +484,49 @@ the fail-open path leaves Claude's original text untouched. Point a hotkey at a
 two-line toggle script to flip rewrites from the keyboard across all running
 sessions at once. Override the path with `CLAUDISH_OFF_FILE`.
 
+### The `/claudish` command
+
+The plugin ships a slash command that drives the flag files for you, so
+everything switches mid-session without restarting:
+
+```
+/claudish                    # cycle: off -> append -> replace -> off
+/claudish on                 # resume rewrites (keeps the current mode)
+/claudish off                # pause rewrites (originals only; both hooks)
+/claudish append             # original + rewrite appended (and turn on)
+/claudish replace            # rewrite only (and turn on)
+/claudish style tldr         # short summary instead of a full rewrite
+/claudish style 5y           # explain like I'm five
+/claudish style default      # back to the plain-language rewrite
+/claudish language french    # rewrite into French from the next message
+/claudish language default   # back to the env / settings language
+/claudish model gemma4:12b   # switch the rewrite model
+/claudish model default      # back to the env / provider default
+/claudish status             # show the current state
+/claudish last               # reprint the ORIGINAL text of the last message
+```
+
+Under the hood, `on`/`off` drive the off-file described above, and every other
+subcommand writes a `key=value` line into ONE runtime file next to it
+(`~/.claude/claudish-runtime`, path overridable with `CLAUDISH_RUNTIME_FILE`):
+`mode=`, `style=`, `language=`, `model=`. The hooks re-read it on every
+message, so the switch applies from the next assistant message on — and to
+every running session at once. Env vars keep working as the launch-time
+defaults; a key, while present, wins over the corresponding env var, and
+resetting everything to `default` removes the file.
+
+The `style` presets only swap the display hook's **built-in** prompt (the
+on-screen label follows: `💬 TL;DR:` / `💬 Like you're five:`); the language
+still applies, and a custom `CLAUDISH_PROMPT_FILE` always wins over any style.
+The Markdown file hook is not affected by styles.
+
+`/claudish last` exists because the rewrite is display-only: the transcript
+always keeps Claude's original text, and the command reprints the last
+assistant message from it — handy in `replace` mode when you want to check the
+full original of just one reply (`ctrl+o` shows the whole original chat). Such
+reprints start with a `<!-- claudish:original -->` marker line that tells the
+display hook not to rewrite that reply; the marker is stripped from view.
+
 ### Reasoning models
 
 The ollama request sends `"think": false`, and openai-provider requests to
@@ -512,6 +557,9 @@ claudish-to-english/
 │   └── marketplace.json    # so the repo can be added as a marketplace directly
 ├── hooks/
 │   └── hooks.json          # MessageDisplay -> rewrite.sh ; PostToolUse -> rewrite-md.sh
+├── commands/
+│   └── claudish.md         # /claudish slash command (runtime switching)
+├── claudish-ctl.sh         # flag-file switcher backing /claudish
 ├── rewrite.sh              # display-rewrite hook
 ├── rewrite-md.sh           # markdown-file rewrite hook (opt-in)
 ├── providers.sh            # provider layer (ollama/anthropic/openai), sourced by both hooks

--- a/claudish-ctl.sh
+++ b/claudish-ctl.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+# ---------------------------------------------------------------------------
+# claudish-ctl.sh — runtime state switcher backing the /claudish command.
+#
+# Env vars are frozen at session launch, so nothing can flip CLAUDISH_* mid-
+# session. Files can: the hooks re-read these on every message. This script
+# only writes/removes them — the hooks do the rest.
+#   off-file      (default ~/.claude/claudish-off)      exists -> rewrites
+#                 paused (the pre-existing kill switch, unchanged)
+#   runtime file  (default ~/.claude/claudish-runtime)  key=value lines that
+#                 override the matching env vars while present:
+#                   mode=append|replace   display mode      (rewrite.sh)
+#                   style=tldr|5y         rewrite style     (rewrite.sh)
+#                   language=<name>       output language   (lang.sh, cleaned)
+#                   model=<name>          model, both hooks (providers.sh)
+#
+# Usage: claudish-ctl.sh [on|off|append|replace|style [name]|language [name]|model [name]|last|status|cycle]
+#   on            resume rewrites (keeps the current mode)
+#   off           pause rewrites (originals only; also pauses the Markdown hook)
+#   append        original + rewrite appended (and turn on)
+#   replace       rewrite only (and turn on)
+#   style X       rewrite style: "tldr" (short summary) or "5y" (explain like
+#                 I'm five); no name / "default" resets to the plain rewrite.
+#                 A custom CLAUDISH_PROMPT_FILE always wins over styles
+#   language X    rewrite into language X, e.g. "language french"
+#                 (no name / "default" resets to the env/settings; turns on)
+#   model X       use model X, e.g. "model gemma4:12b" (no name / "default"
+#                 resets to the env/provider default; turns on)
+#   last          print the ORIGINAL text of the last assistant message, taken
+#                 from the most recent session transcript (useful in replace
+#                 mode; ctrl+o shows the whole original chat)
+#   status        print the current state
+#   cycle         off -> append -> replace -> off (default with no argument)
+#
+# Prints the resulting state as "claudish: <off|append|replace> (...)".
+# ---------------------------------------------------------------------------
+set -uo pipefail
+
+OFF_FILE="${CLAUDISH_OFF_FILE:-$HOME/.claude/claudish-off}"
+RUNTIME_FILE="${CLAUDISH_RUNTIME_FILE:-$HOME/.claude/claudish-runtime}"
+
+SELF_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# The slash command passes everything the user typed as ONE quoted string, so
+# nothing in it is ever shell syntax. Split it into arguments here (plain
+# word splitting, globbing off — never eval).
+if [ $# -le 1 ]; then
+  set -f
+  # shellcheck disable=SC2086
+  set -- ${1:-}
+  set +f
+fi
+
+fail() { printf 'claudish-ctl: %s\n' "$1" >&2; exit 1; }
+
+get_key() { sed -n "s/^$1=//p" "$RUNTIME_FILE" 2>/dev/null | head -n1; }
+
+# set_key KEY VALUE — replace/append one key=value line, preserving the other
+# keys; an empty VALUE removes the key. The file is removed once empty, so
+# "everything default" is the same absent-file state as a fresh install.
+set_key() {
+  _rest="$(grep -v "^$1=" "$RUNTIME_FILE" 2>/dev/null | grep -v '^$')" || _rest=""
+  {
+    { [ -z "$_rest" ] || printf '%s\n' "$_rest"; } &&
+    { [ -z "$2" ]     || printf '%s=%s\n' "$1" "$2"; }
+  } 2>/dev/null > "$RUNTIME_FILE" || fail "cannot write $RUNTIME_FILE"
+  [ -s "$RUNTIME_FILE" ] || rm -f "$RUNTIME_FILE"
+}
+
+current_mode() {
+  case "$(get_key mode | tr -d '[:space:]')" in
+    append)  printf 'append' ;;
+    replace) printf 'replace' ;;
+    *)       printf '%s' "${CLAUDISH_MODE:-append}" ;;
+  esac
+}
+
+current_style() {
+  case "$(get_key style | tr -d '[:space:]')" in
+    tldr) printf 'tldr' ;;
+    5y)   printf '5y' ;;
+    *)    case "${CLAUDISH_STYLE:-}" in tldr|5y) printf '%s' "$CLAUDISH_STYLE" ;; *) printf 'default' ;; esac ;;
+  esac
+}
+
+state() { [ -f "$OFF_FILE" ] && printf 'off' || current_mode; }
+
+turn_on() { rm -f "$OFF_FILE" 2>/dev/null || fail "cannot remove $OFF_FILE"; }
+
+set_mode() { set_key mode "$1"; turn_on; }
+
+cmd="${1:-cycle}"
+case "$cmd" in
+  last)
+    # The rewrite is display-only: transcripts always keep Claude's original
+    # text. Transcripts live under ~/.claude/projects/<encoded cwd>/, so scope
+    # the search to the CURRENT project's directory (the command runs in the
+    # session's cwd) and take the most recently touched transcript there —
+    # with several sessions open on the SAME project that is still the best
+    # available guess. Fall back to all projects when the encoded directory
+    # does not exist (e.g. the session moved into a subdirectory).
+    proj="$(printf '%s' "$PWD" | sed 's/[^A-Za-z0-9]/-/g')"
+    tp="$(ls -t "$HOME/.claude/projects/$proj"/*.jsonl 2>/dev/null | head -n1)"
+    [ -n "$tp" ] || tp="$(ls -t "$HOME/.claude/projects"/*/*.jsonl 2>/dev/null | head -n1)"
+    [ -n "$tp" ] || { printf 'claudish-ctl: no session transcript found\n' >&2; exit 1; }
+    jq -rs '
+      [ .[]
+        | select(.type=="assistant" and .isSidechain!=true)
+        | [.message.content[]? | select(.type=="text") | .text]
+        | join("\n\n")
+        | select(length>0) ]
+      | last // "claudish-ctl: no assistant message in the transcript yet"
+    ' "$tp" 2>/dev/null || { printf 'claudish-ctl: could not parse %s\n' "$tp" >&2; exit 1; }
+    exit 0
+    ;;
+  on)      turn_on ;;
+  off)     : > "$OFF_FILE" 2>/dev/null || fail "cannot create $OFF_FILE" ;;
+  append)  set_mode append ;;
+  replace) set_mode replace ;;
+  style)
+    s="$(printf '%s' "${2:-}" | tr -d '[:space:]')"
+    case "$s" in
+      ''|default|Default) set_key style "" ;;
+      tldr|5y)            set_key style "$s" ;;
+      *) printf 'claudish-ctl: unknown style "%s" (use tldr|5y|default)\n' "$s" >&2; exit 2 ;;
+    esac
+    turn_on
+    ;;
+  language)
+    # Stored raw (capped, keys stop at the first newline); lang.sh cleans it
+    # on every read exactly like the env and settings sources — a language
+    # name survives, free text does not.
+    shift
+    lang="$(printf '%.200s' "$*" | tr -d '\n')"
+    case "$lang" in
+      ''|default|Default) set_key language "" ;;
+      *)                  set_key language "$lang" ;;
+    esac
+    turn_on
+    ;;
+  model)
+    # Sanitise to the characters model names use (providers.sh re-checks).
+    m="$(printf '%s' "${2:-}" | tr -cd 'A-Za-z0-9:._/-' | head -c 64)"
+    case "$m" in
+      ''|default|Default) set_key model "" ;;
+      *)                  set_key model "$m" ;;
+    esac
+    turn_on
+    ;;
+  status)  ;;
+  cycle)
+    case "$(state)" in
+      off)    set_mode append ;;
+      append) set_mode replace ;;
+      *)      : > "$OFF_FILE" 2>/dev/null || fail "cannot create $OFF_FILE" ;;
+    esac
+    ;;
+  *)
+    printf 'claudish-ctl: unknown command "%s" (use on|off|append|replace|style [name]|language [name]|model [name]|last|status|cycle)\n' "$cmd" >&2
+    exit 2
+    ;;
+esac
+
+# Status line: source the hooks' own resolvers, so what is printed is exactly
+# what the next rewrite will use (provider default model, runtime file,
+# settings fallbacks included). Either file missing degrades to a placeholder.
+dbg() { :; }
+MODEL=""
+. "$SELF_DIR/providers.sh" 2>/dev/null || true
+claudish_language() { :; }
+. "$SELF_DIR/lang.sh" 2>/dev/null || true
+lang="$(claudish_language "$PWD" 2>/dev/null)"
+printf 'claudish: %s (style: %s, language: %s, model: %s)\n' \
+  "$(state)" "$(current_style)" "${lang:-session default}" "${MODEL:-unknown}"

--- a/commands/claudish.md
+++ b/commands/claudish.md
@@ -1,0 +1,9 @@
+---
+description: Switch the rewrite on the fly — on, off, append, replace, "style tldr|5y", "language <name>", "model <name>", or "last" to reprint the original of the last message (no argument cycles off → append → replace)
+argument-hint: "[on|off|append|replace|style <tldr|5y|default>|language <name>|model <name>|last|status]"
+allowed-tools: Bash("${CLAUDE_PLUGIN_ROOT}"/claudish-ctl.sh:*)
+---
+
+Claudish state after applying "$ARGUMENTS": !`"${CLAUDE_PLUGIN_ROOT}/claudish-ctl.sh" "$ARGUMENTS"`
+
+If the argument was "last", the script output above is the ORIGINAL text of the last assistant message: reply with the literal line `<!-- claudish:original -->` as the VERY FIRST line (it tells the display hook not to rewrite this reply and is stripped from view), then one short intro line (remind the user that ctrl+o shows the whole original chat), then the text verbatim. Otherwise tell the user the resulting claudish state in one short line (off = originals only; append = original + rewrite; replace = rewrite only; style tldr = short summary, 5y = explain like I'm five, default = plain rewrite; "language: session default" means the language follows the env/settings as usual). If the script errored, show its message instead. Do nothing else.

--- a/lang.sh
+++ b/lang.sh
@@ -8,6 +8,12 @@
 # leaves the rewrite in whatever language the text it rewrites is already
 # written in. English is not a default here, only one possible answer.
 # First non-empty source wins:
+#   0. language= in the runtime file      written by the /claudish command
+#                                         (claudish-ctl.sh); re-read per
+#                                         message, so the language switches
+#                                         mid-session while the env cannot
+#                                         (default ~/.claude/claudish-runtime,
+#                                         path: CLAUDISH_RUNTIME_FILE)
 #   1. CLAUDISH_LANG                      explicit override. Set but EMPTY
 #                                         ignores the settings below and keeps
 #                                         the text's own language; set it to
@@ -42,6 +48,15 @@ _claudish_lang_clean() {
 }
 
 claudish_language() {
+  # Runtime override written by /claudish (claudish-ctl.sh): unlike the env,
+  # the runtime file can be re-read on every message. Its content is user
+  # text, so it goes through the same cleaning as every other source before
+  # it lands in the prompt. Missing file/key/value -> fall through to the env.
+  _cl_ff="${CLAUDISH_RUNTIME_FILE:-${HOME:-}/.claude/claudish-runtime}"
+  _cl_v="$(sed -n 's/^language=//p' "$_cl_ff" 2>/dev/null | head -n1 | head -c 200)"
+  _cl_v="$(_claudish_lang_clean "$_cl_v")"
+  if [ -n "$_cl_v" ]; then printf '%s' "$_cl_v"; return 0; fi
+
   # An explicitly set CLAUDISH_LANG always wins, including an explicitly EMPTY
   # one — the escape hatch for keeping rewrites in English on a session that
   # speaks something else.

--- a/providers.sh
+++ b/providers.sh
@@ -27,6 +27,11 @@
 #
 # Extra config:
 #   CLAUDISH_MODEL          overrides the per-provider default model
+#   CLAUDISH_RUNTIME_FILE   key=value file written by /claudish
+#                           (claudish-ctl.sh); its model= key overrides
+#                           CLAUDISH_MODEL and is re-read per message, so the
+#                           model switches mid-session (default
+#                           ~/.claude/claudish-runtime)
 #   CLAUDISH_MAX_TOKENS     completion cap for the anthropic provider (default
 #                           4096; the Messages API requires an explicit cap)
 #   CLAUDISH_OPENAI_EFFORT  reasoning_effort for the openai provider. Unset
@@ -75,6 +80,14 @@ case "$PROVIDER" in
   openai)    MODEL="${CLAUDISH_MODEL:-gpt-5.6-luna}" ;;
   *)         MODEL="${CLAUDISH_MODEL:-gemma4:26b-mlx}" ;;
 esac
+
+# Runtime model override written by /claudish (claudish-ctl.sh): unlike the
+# env, the runtime file's model= key can be re-read on every message.
+# Sanitised to the characters model names use, and capped, since it lands in
+# the request body.
+_pm_f="${CLAUDISH_RUNTIME_FILE:-${HOME:-}/.claude/claudish-runtime}"
+_pm="$(sed -n 's/^model=//p' "$_pm_f" 2>/dev/null | head -n1 | tr -cd 'A-Za-z0-9:._/-' | head -c 64)"
+[ -n "$_pm" ] && MODEL="$_pm"
 
 # Split the "\n<status>" suffix appended by curl -w '\n%{http_code}' off $resp
 # into $http. "000" (no response at all) is normalized to "".

--- a/rewrite.sh
+++ b/rewrite.sh
@@ -31,9 +31,27 @@
 #                                          ~/.claude/claudish-off) — lets a
 #                                          hotkey/script toggle mid-session
 #   CLAUDISH_MODE      append|replace display strategy (default append)
+#   CLAUDISH_RUNTIME_FILE <path>      key=value file written by the /claudish
+#                                          command (claudish-ctl.sh) and
+#                                          re-read per message, so its keys
+#                                          override the env mid-session:
+#                                          mode= (this hook), style= (this
+#                                          hook), language= (lang.sh), model=
+#                                          (providers.sh). Default
+#                                          ~/.claude/claudish-runtime
+#   CLAUDISH_STYLE     tldr|5y        rewrite-style preset replacing the base
+#                                          prompt: "tldr" = a clearly shorter
+#                                          summary; "5y" = explain like I'm
+#                                          five. Unset/other = the default
+#                                          plain-language rewrite. A usable
+#                                          CLAUDISH_PROMPT_FILE wins over any
+#                                          style (custom prompt > style >
+#                                          built-in); the language line applies
+#                                          to styles as usual
 #   CLAUDISH_PROMPT_FILE <path>       file holding a replacement rewrite prompt
 #                                          (whole prompt, not merged; empty or
-#                                          unreadable -> built-in default)
+#                                          unreadable -> built-in default,
+#                                          overriding any CLAUDISH_STYLE)
 #   CLAUDISH_LANG      <language>     language to rewrite into, e.g. "Esperanto".
 #                                          Unset falls back to the session's
 #                                          `language` setting from
@@ -69,6 +87,22 @@ ENABLED="${CLAUDISH_ENABLED:-1}"
 # every invocation. Create it to pause rewrites instantly; remove it to resume.
 [ -f "${CLAUDISH_OFF_FILE:-$HOME/.claude/claudish-off}" ] && ENABLED=0
 MODE="${CLAUDISH_MODE:-append}"
+# Runtime overrides: like the off-file, a file can be re-read per message
+# while the env cannot. /claudish (claudish-ctl.sh) writes key=value lines
+# into ONE runtime file; each consumer takes only its own key and validates
+# the value — anything unknown falls back to the env. This hook reads mode=
+# and style=; lang.sh reads language= and providers.sh reads model=.
+RUNTIME_FILE="${CLAUDISH_RUNTIME_FILE:-$HOME/.claude/claudish-runtime}"
+case "$(sed -n 's/^mode=//p' "$RUNTIME_FILE" 2>/dev/null | head -n1 | tr -d '[:space:]')" in
+  append)  MODE=append ;;
+  replace) MODE=replace ;;
+esac
+STYLE=""
+case "${CLAUDISH_STYLE:-}" in tldr|5y) STYLE="$CLAUDISH_STYLE" ;; esac
+case "$(sed -n 's/^style=//p' "$RUNTIME_FILE" 2>/dev/null | head -n1 | tr -d '[:space:]')" in
+  tldr) STYLE=tldr ;;
+  5y)   STYLE=5y ;;
+esac
 MIN_CHARS="${CLAUDISH_MIN_CHARS:-200}"
 STUB="${CLAUDISH_STUB:-0}"
 LLM_TIMEOUT="${CLAUDISH_TIMEOUT:-45}"
@@ -147,8 +181,26 @@ mkdir -p "$mdir" 2>/dev/null || pass_through
 printf '%s' "$payload" | jq -j '.delta // ""' > "$mdir/$(printf '%08d' "$idx").part" 2>/dev/null || pass_through
 dbg "chunk idx=$idx final=$final mid=$mid mode=$MODE"
 
+# ---- opt-out marker -------------------------------------------------------
+# A message that BEGINS with this marker is never rewritten (used by
+# /claudish last, whose whole point is reprinting an original message —
+# rewriting it again would defeat it). The marker is stripped from the display.
+SKIP_MARK='<!-- claudish:original -->'
+strip_mark() { s="${1#"$SKIP_MARK"}"; s="${s#$'\n'}"; s="${s#$'\n'}"; printf '%s' "$s"; }
+if [ "$idx" = "0" ]; then
+  case "$(cat "$mdir/00000000.part" 2>/dev/null)" in
+    "$SKIP_MARK"*) : > "$mdir/skip" 2>/dev/null ;;
+  esac
+fi
+
 # ---- non-final chunks ----------------------------------------------------
 if [ "$final" != "true" ]; then
+  # Marked message in append mode: stream it, but hide the marker in chunk 0.
+  if [ -f "$mdir/skip" ] && [ "$MODE" != "replace" ] && [ "$idx" = "0" ]; then
+    out="$BUF_ROOT/$sid.$mid.strip"
+    strip_mark "$(cat "$mdir/00000000.part" 2>/dev/null)" > "$out" 2>/dev/null && emit "$out"
+    pass_through
+  fi
   # append: let the original stream through untouched.
   # replace: suppress the streamed original; the whole rewrite lands on final.
   if [ "$MODE" = "replace" ]; then emit_empty; else pass_through; fi
@@ -165,6 +217,18 @@ prose_len="$(printf '%s' "$full" \
 dbg "final: prose_len=$prose_len min=$MIN_CHARS mode=$MODE full_bytes=${#full}"
 
 cleanup() { rm -rf "$mdir" 2>/dev/null || true; }
+
+# Marked message -> never rewrite; re-show the original without the marker.
+# (replace mode blanked every previous chunk, so it needs the whole message;
+# append mode streamed chunk 0 already stripped, so only the final delta.)
+if [ -f "$mdir/skip" ]; then
+  dbg "skip: original-reprint marker"
+  out="$BUF_ROOT/$sid.$mid.orig"
+  if [ "$MODE" = "replace" ]; then src="$full"; else src="$(cat "$final_part" 2>/dev/null)"; fi
+  cleanup
+  strip_mark "$src" > "$out" 2>/dev/null && emit "$out"
+  pass_through
+fi
 
 # Below threshold -> do not rewrite.
 if [ "${prose_len:-0}" -lt "$MIN_CHARS" ]; then
@@ -183,8 +247,12 @@ fi
 # here needs it. Empty -> the rewrite follows the language of the message, so
 # the label must not claim one either.
 OUT_LANG="$(claudish_language "$cwd")"
-SEP=$'\n\n────────────────────────\n💬 In plain '"${OUT_LANG:-language}"$':\n\n'
-dbg "language=${OUT_LANG:-same as the message (default)}"
+case "$STYLE" in
+  tldr) SEP=$'\n\n────────────────────────\n'"💬 TL;DR${OUT_LANG:+ in $OUT_LANG}:"$'\n\n' ;;
+  5y)   SEP=$'\n\n────────────────────────\n'"💬 Like you're five${OUT_LANG:+, in $OUT_LANG}:"$'\n\n' ;;
+  *)    SEP=$'\n\n────────────────────────\n💬 In plain '"${OUT_LANG:-language}"$':\n\n' ;;
+esac
+dbg "language=${OUT_LANG:-same as the message (default)} style=${STYLE:-default}"
 
 # ---- obtain the rewrite --------------------------------------------------
 rewrite=""
@@ -199,6 +267,13 @@ else
   # whole prompt). An unset/empty/unreadable file falls back to this default, so
   # a bad path never stops rewrites — it just uses the built-in prompt.
   sys="You rewrite the assistant's message into much simpler, plain language. Write the rewrite in the same language as the message you are rewriting. Keep every fact, name, number, and file path. Use short sentences and everyday words. Leave fenced code blocks unchanged. Output ONLY the rewritten message with no preamble, labels, or commentary."
+  # Style presets replace the BASE prompt only: the language line below still
+  # applies, and a usable CLAUDISH_PROMPT_FILE still replaces everything —
+  # custom prompt > style > built-in.
+  case "$STYLE" in
+    tldr) sys="You rewrite the assistant's message as a SHORT summary in simple, plain language. This is a simplification, NOT a translation: it must be clearly shorter than the original — aim for half its length or less. Keep the key facts, decisions, numbers, and file paths; drop repetitions, hedges, and secondary detail. Keep technical terms, commands, and identifiers in their original form. Use short sentences and everyday words. Omit fenced code blocks (the original text is always in the transcript). Write the rewrite in the same language as the message you are rewriting. Output ONLY the rewritten message with no preamble, labels, or commentary." ;;
+    5y)   sys="You rewrite the assistant's message as if explaining it to a five-year-old: very simple words, short sentences, a friendly tone, and simple comparisons for hard ideas. Keep every important fact, name, number, and file path accurate. Keep technical terms, commands, and identifiers in their original form. Leave fenced code blocks unchanged. Write the rewrite in the same language as the message you are rewriting. Output ONLY the rewritten message with no preamble, labels, or commentary." ;;
+  esac
   # A configured language overrides "same language as the message" — it is the
   # last word in the prompt, and it names the language explicitly. The line goes
   # on BEFORE the prompt-file check on purpose: a usable CLAUDISH_PROMPT_FILE


### PR DESCRIPTION
This PR adds a `/claudish` slash command so everything the plugin already lets you configure at launch time can also be switched mid-session, plus two rewrite-style presets. It grew out of my fork ([MakhBeth/claudish-tldr](https://github.com/MakhBeth/claudish-tldr)) and the [Reddit discussion](https://www.reddit.com/r/ClaudeAI/comments/1vl0n1t/comment/p4lyidc/) — porting it back upstream where it belongs.

## What it does

```
/claudish                    # cycle: off -> append -> replace -> off
/claudish on | off           # resume / pause rewrites (drives the existing off-file)
/claudish append | replace   # display mode
/claudish style tldr|5y      # short summary / explain like I'm five (default = plain rewrite)
/claudish language french    # output language (default = env/settings, as today)
/claudish model gemma4:12b   # model, both hooks (default = env/provider default)
/claudish status             # current state
/claudish last               # reprint the ORIGINAL of the last assistant message
```

## Design

- **One runtime file.** Env vars are frozen at session launch, so the command writes `key=value` lines (`mode=`, `style=`, `language=`, `model=`) into a single `~/.claude/claudish-runtime` file that the hooks re-read on every message — the same trick as the existing off-file, which `on`/`off` reuse unchanged. Env vars stay the launch-time defaults; a key wins while present; resetting everything to `default` removes the file.
- **Each consumer validates its own key.** `rewrite.sh` honours only `append|replace` and `tldr|5y`; `language=` goes through the exact same `_claudish_lang_clean` pipeline as the settings key; `model=` is sanitised in `providers.sh` to the characters model names use. Unknown values fall back to the env, and a missing/broken file changes nothing, so the fail-open contract is untouched.
- **Style presets replace only the built-in base prompt.** The language line still applies, a usable `CLAUDISH_PROMPT_FILE` wins over any style, and the Markdown hook is unaffected. The on-screen label follows the style (`💬 TL;DR:`, `💬 Like you're five:`).
- **`/claudish last`** works because the rewrite is display-only: the transcript keeps the original, and the command reprints the last assistant message from the current project's most recent transcript. Such replies start with a `<!-- claudish:original -->` marker the display hook strips and never rewrites, so the reprint survives `replace` mode.

Diff is additions-only outside the docs: no existing line of hook behaviour changes when the runtime file is absent.

## Testing

- `claudish-ctl.sh`: full subcommand matrix (cycle, style/language/model set + reset, key preservation in the runtime file, file removal when all-default, loud failure on unwritable paths, injection attempts via the quoted-argument path).
- `rewrite.sh` in stub mode: `mode=replace` via runtime file, per-style labels, marker skip in append/replace and single-chunk messages, off-file precedence, malformed/hostile runtime-file values falling back to the env.
- Real request bodies against a local fake ollama server: style prompts and language line land in `messages[0]`, `CLAUDISH_PROMPT_FILE` wins over styles, `model=` reaches the request.

Happy to split, rename, or trim — the version-bump/changelog placement is left to you (changes are under `[Unreleased]`).
