### PR TITLE
Add /claudish runtime control command (v0.5.0)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claudish-to-english",
-  "description": "Shows a plain-English rewrite of each Claude Code assistant message, produced by a local LLM (ollama, default), the Anthropic API, or any OpenAI-compatible API. Display-only: Claude's reasoning and the transcript keep the original text.",
-  "version": "0.4.0",
+  "description": "Shows a plain-language rewrite of each Claude Code assistant message, produced by a local LLM (ollama, default), the Anthropic API, or any OpenAI-compatible API. Switch it on the fly with /claudish (on/off, append/replace, language, model). Display-only: Claude's reasoning and the transcript keep the original text.",
+  "version": "0.5.0",
   "author": {
     "name": "Mike Gvozdev",
     "email": "mv.gvozdev@gmail.com",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,46 @@ All notable changes to this project are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2026-08-19
+
+### Added
+- The `/claudish` slash command for mid-session control, backed by
+  `claudish-ctl.sh`. It switches rewrites on the fly — `on`/`off`,
+  `append`/`replace`, `language <name>`, `model <name>`, `last` (reprint the
+  original of the last message), `cycle`, and `reset` — by writing flag files
+  the hooks re-read every message, so changes take effect without relaunching.
+- A `/claudish` dashboard (bare `/claudish`, or `status`). It lists each
+  setting, its current value, and where that value comes from — an env var, a
+  `/claudish` override, `settings.json`, or the default — flagging every
+  persisting override with ⚠ so its cross-session persistence is never silent.
+- A `SessionStart` hook (`session-notice.sh`) that prints a one-line notice at
+  the start of any new session with leftover `/claudish` overrides active, so a
+  language or model set in an earlier session never applies silently. Gated by
+  `CLAUDISH_NOTICE`; `/claudish reset` clears all overrides at once.
+- Rewrite-style presets for the display hook: `/claudish style tldr` (a short
+  summary) and `5y` (explain like I'm five), also settable at launch with
+  `CLAUDISH_STYLE` or live via `CLAUDISH_STYLE_FILE`. A style replaces only the
+  built-in base prompt — the output language still applies, and a
+  `CLAUDISH_PROMPT_FILE` still wins (custom prompt > style > built-in). The
+  on-screen label follows the style (`💬 TL;DR:`, `💬 Like you're five:`).
+  Ported from [PR #17](https://github.com/gvzdv/claudish-to-english/pull/17).
+- `/claudish language` now accepts multi-word names (e.g. `Brazilian
+  Portuguese`); `/claudish last` prefers the current project's most recent
+  transcript before falling back to all projects; and `claudish-ctl.sh` fails
+  loudly if it cannot write a flag file instead of proceeding silently.
+- Runtime flag-file overrides that back the command, each sitting above its env
+  var and re-checked per message: `CLAUDISH_MODE_FILE` (`~/.claude/claudish-mode`,
+  read by the display hook), `CLAUDISH_LANG_FILE` (`~/.claude/claudish-lang`) and
+  `CLAUDISH_MODEL_FILE` (`~/.claude/claudish-model`), both read by `lang.sh` /
+  `providers.sh` and so honoured by both hooks. This generalises the existing
+  `CLAUDISH_OFF_FILE` pattern to mode, language, and model.
+- `/claudish last` reprints an assistant message's original text; the display
+  hook now recognises a leading `<!-- claudish:original -->` marker and passes
+  such a reply through unrewritten (the marker is stripped from view).
+
+Ported from the [claudish-tldr](https://github.com/MakhBeth/claudish-tldr) fork
+by Davide Di Pumpo, adapted to the provider layer and language resolver.
+
 ## [0.4.0] - 2026-08-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -162,9 +162,18 @@ Run `/reload-plugins` after edits; if it doesn't load, check the `/plugin`
 
 ## Configuring the plugin
 
-All behavior is controlled by `CLAUDISH_*` environment variables (full list in
-[Configuration](#configuration-env-vars) below). When you install from a
-marketplace, set them in Claude Code's **`env` block in `settings.json`** — do
+There are two ways to control claudish, and they complement each other:
+
+- **`/claudish`** — a slash command for live, day-to-day toggles: on/off, display
+  mode, language, and model. Changes take effect immediately, mid-session. This
+  is what most people reach for. See
+  [Controlling it live](#controlling-it-live-claudish).
+- **`CLAUDISH_*` environment variables** — your durable defaults, and the only
+  way to set everything `/claudish` doesn't cover (provider, API keys, base URLs,
+  the Markdown hook, timeouts). Full list in
+  [Configuration](#configuration-env-vars) below.
+
+Set the durable ones in Claude Code's **`env` block in `settings.json`** — do
 **not** edit the plugin's own `hooks/hooks.json`, which lives in the read-only
 plugin cache (`~/.claude/plugins/cache/…`) and is overwritten on every update.
 
@@ -200,6 +209,64 @@ CLAUDISH_MODEL=llama3.2:3b claude
 
 To confirm the hook is firing, set `CLAUDISH_DEBUG=1` and watch
 `"$TMPDIR"/claudish-to-english/debug.log`.
+
+---
+
+## Controlling it live: `/claudish`
+
+`/claudish` is the interactive front-end for the four most-used settings —
+on/off, display mode, language, and model. Changes take effect on the next
+assistant message, mid-session, with nothing to relaunch:
+
+```
+/claudish              show the dashboard (current state + where each value comes from)
+/claudish on           resume rewrites (keeps the current mode)
+/claudish off          pause rewrites (originals only; also pauses the Markdown hook)
+/claudish append       show the original, then the rewrite below it
+/claudish replace      show only the rewrite
+/claudish style tldr   rewrite as a short summary (or "5y" = explain like I'm five)
+/claudish style        reset to the default plain-language rewrite
+/claudish language fr  rewrite into French (any name, incl. non-Latin like 简体中文)
+/claudish language     reset to the session/settings language (see "Output language")
+/claudish model X      use model X for whatever provider is configured
+/claudish model        reset to the provider default
+/claudish last         reprint the ORIGINAL of the last message (handy in replace mode)
+/claudish cycle        step off → append → replace → off
+/claudish reset        clear ALL overrides — back to your env/settings defaults
+```
+
+Bare `/claudish` prints a **dashboard** — each setting, its current value, and
+where that value comes from (an env var, a `/claudish` override, your
+`settings.json`, or the default):
+
+```
+  claudish · plain-language rewrite of each assistant message
+
+  status    replace          · ⚠ /claudish — rewrite only; beats env, persists across sessions
+  style     tldr             · ⚠ /claudish — beats env CLAUDISH_STYLE, persists across sessions
+  language  French           · ⚠ /claudish — beats env & settings, persists across sessions
+  model     gemma4:26b-mlx   · ollama provider default
+  provider  ollama           · default
+```
+
+Each switch writes a small flag file under `~/.claude/` that the hooks re-read
+every message (the paths and their `CLAUDISH_*_FILE` overrides are in the
+[env-var table](#configuration-env-vars); the underlying mechanism is under
+[Toggling mid-session](#toggling-mid-session)). A live `/claudish` switch **beats
+the matching env var** — `CLAUDISH_MODE`, `CLAUDISH_LANG`, or `CLAUDISH_MODEL`.
+
+**These overrides persist across sessions** (like the off-file), until you clear
+them with the per-setting `default` form, `/claudish on`, or `/claudish reset`.
+So a `/claudish language French` set today still applies to a session you open
+tomorrow. The state is never silent, though: the dashboard flags every persisting
+override with ⚠, and a `SessionStart` notice lists any that are active at the top
+of a new session (`CLAUDISH_NOTICE=0` silences it). For a *permanent* default,
+set the matching env var in `settings.json` rather than using `/claudish`.
+
+`/claudish last` works because the rewrite is display-only: the transcript always
+keeps Claude's original text, so the command just reprints it (prefixed with an
+internal `<!-- claudish:original -->` marker that tells the display hook not to
+rewrite that reply, and which is stripped from view).
 
 ---
 
@@ -243,10 +310,15 @@ else. If non-English results disappoint, try a larger model or a cloud provider
 ## Customizing the rewrite prompt
 
 Each hook ships with a default system prompt that asks the model for plain
-language while preserving facts, code, and structure. You can **replace** either
-prompt with your own to add specific rules or use wording that works
-better with your model. To do so, point the hook at a file that holds
-the prompt:
+language while preserving facts, code, and structure.
+
+For a quick change of tone without writing a prompt, the display hook also has
+two **built-in style presets** — `tldr` (a short summary) and `5y` (explain like
+I'm five) — set with [`/claudish style`](#controlling-it-live-claudish) or
+`CLAUDISH_STYLE`. For full control, you can instead **replace** either prompt
+with your own to add specific rules or use wording that works better with your
+model (this wins over a style preset). To do so, point the hook at a file that
+holds the prompt:
 
 | Hook | Prompt file |
 |---|---|
@@ -431,10 +503,15 @@ Notes:
 | `CLAUDISH_ENABLED` | `1` | Master switch. `0` = pass everything through. Read once at session start. |
 | `CLAUDISH_OFF_FILE` | `~/.claude/claudish-off` | Runtime kill switch. While this file exists, rewrites pause — re-checked every message, so unlike env vars it works mid-session. See [Toggling mid-session](#toggling-mid-session). |
 | `CLAUDISH_MODE` | `append` | `append` or `replace` (display hook). |
+| `CLAUDISH_MODE_FILE` | `~/.claude/claudish-mode` | Runtime display-mode override: `append`/`replace` in this file wins over `CLAUDISH_MODE`, re-checked every message. Written by `/claudish append`/`replace`. See [Controlling it live](#controlling-it-live-claudish). |
+| `CLAUDISH_STYLE` | *(unset)* | Rewrite-style preset (display hook): `tldr` = a clearly shorter summary, `5y` = explain like I'm five. Unset = the default plain-language rewrite. A usable `CLAUDISH_PROMPT_FILE` wins over any style (custom prompt > style > built-in); the output language still applies. |
+| `CLAUDISH_STYLE_FILE` | `~/.claude/claudish-style` | Runtime style override: `tldr`/`5y` in this file wins over `CLAUDISH_STYLE`, re-checked every message. Written by `/claudish style <tldr\|5y>`. See [Controlling it live](#controlling-it-live-claudish). |
 | `CLAUDISH_PROMPT_FILE` | *(unset)* | Path to a file whose contents replace the display hook's system prompt (whole prompt, not merged). Empty/unreadable falls back to the built-in default. See [Customizing the rewrite prompt](#customizing-the-rewrite-prompt). |
 | `CLAUDISH_LANG` | *(unset)* | Language to rewrite into, e.g. `Esperanto`. Unset falls back to the `language` key in `.claude/settings*.json`; with neither set, the rewrite keeps the input's language. Empty ignores the settings key; `English` forces English. See [Output language](#output-language). |
+| `CLAUDISH_LANG_FILE` | `~/.claude/claudish-lang` | Runtime language override: a language name in this file wins over `CLAUDISH_LANG` and the settings key, re-checked every message. Written by `/claudish language <name>`. See [Controlling it live](#controlling-it-live-claudish). |
 | `CLAUDISH_PROVIDER` | `ollama` | `ollama`, `anthropic`, or `openai` — which LLM serves rewrites (both hooks). |
 | `CLAUDISH_MODEL` | *(per provider)* | Model name; overrides the provider default (see [Providers](#providers)). The ollama default `gemma4:26b-mlx` is MLX (Apple-silicon only; Windows users must override). |
+| `CLAUDISH_MODEL_FILE` | `~/.claude/claudish-model` | Runtime model override: a model name in this file wins over `CLAUDISH_MODEL`, re-checked every message (applies to whatever provider is configured). Written by `/claudish model <name>`. See [Controlling it live](#controlling-it-live-claudish). |
 | `CLAUDISH_OLLAMA` | `http://localhost:11434` | ollama base URL. |
 | `CLAUDISH_ANTHROPIC_KEY` | *(unset)* | Anthropic API key; falls back to `ANTHROPIC_API_KEY`. |
 | `CLAUDISH_OPENAI_KEY` | *(unset)* | OpenAI(-compatible) API key; falls back to `OPENAI_API_KEY`. Only required for api.openai.com. |
@@ -447,7 +524,7 @@ Notes:
 | `CLAUDISH_TIMEOUT` | `45` | LLM client timeout for the **display** hook (seconds). Keep it below that hook's `timeout` (60s). |
 | `CLAUDISH_MD_TIMEOUT` | `150` | LLM client timeout for the **Markdown file** hook (seconds). Higher on purpose — a large model rewriting a long doc is slow. Keep it below the `PostToolUse` hook `timeout` (180s). |
 | `CLAUDISH_DEBUG` | `0` | `1` = write a debug log to `$TMPDIR/claudish-to-english/`. |
-| `CLAUDISH_NOTICE` | `1` | `1` = show a one-time, once-per-session notice when a rewrite is skipped because the provider is unreachable, the call timed out, a key is missing, or the model isn't available (display hook appends it on screen; Markdown hook uses a `systemMessage`). `0` = stay fully silent (pure fail-open). |
+| `CLAUDISH_NOTICE` | `1` | `1` = show a one-time, once-per-session notice when a rewrite is skipped because the provider is unreachable, the call timed out, a key is missing, or the model isn't available (display hook appends it on screen; Markdown hook uses a `systemMessage`). Also gates the `SessionStart` notice that announces leftover `/claudish` overrides. `0` = stay fully silent (pure fail-open). |
 | `CLAUDISH_MD_DIR` | *(unset)* | **Markdown hook opt-in.** Only `*.md` under this directory is rewritten. Unset = the Markdown hook does nothing. |
 | `CLAUDISH_MD_MODE` | `sibling` | `sibling` (`NAME.plain.md`) or `overwrite` (in place). |
 | `CLAUDISH_MD_SUFFIX` | `plain` | Sibling infix: `NAME.<suffix>.md`. |
@@ -480,7 +557,9 @@ You create and remove this file yourself; nothing creates it on install, and its
 absence is the normal "on" state. While it exists, `ENABLED` is forced to `0` and
 the fail-open path leaves Claude's original text untouched. Point a hotkey at a
 two-line toggle script to flip rewrites from the keyboard across all running
-sessions at once. Override the path with `CLAUDISH_OFF_FILE`.
+sessions at once. Override the path with `CLAUDISH_OFF_FILE`. `/claudish`
+([Controlling it live](#controlling-it-live-claudish)) is the friendly front-end
+for this, writing the same kind of flag files for mode, language, and model too.
 
 ### Reasoning models
 
@@ -510,10 +589,14 @@ claudish-to-english/
 ├── .claude-plugin/
 │   ├── plugin.json         # plugin manifest
 │   └── marketplace.json    # so the repo can be added as a marketplace directly
+├── commands/
+│   └── claudish.md         # /claudish slash command (runtime on/off, mode, language, model, last)
 ├── hooks/
-│   └── hooks.json          # MessageDisplay -> rewrite.sh ; PostToolUse -> rewrite-md.sh
+│   └── hooks.json          # SessionStart -> session-notice.sh ; MessageDisplay -> rewrite.sh ; PostToolUse -> rewrite-md.sh
 ├── rewrite.sh              # display-rewrite hook
 ├── rewrite-md.sh           # markdown-file rewrite hook (opt-in)
+├── claudish-ctl.sh         # runtime state switcher + dashboard backing /claudish (writes the flag files)
+├── session-notice.sh       # SessionStart hook: announces leftover /claudish overrides on a new session
 ├── providers.sh            # provider layer (ollama/anthropic/openai), sourced by both hooks
 ├── lang.sh                 # output-language resolver (env + .claude/settings*.json), sourced by both hooks
 ├── CHANGELOG.md            # notable changes per version (Keep a Changelog)

--- a/claudish-ctl.sh
+++ b/claudish-ctl.sh
@@ -1,0 +1,261 @@
+#!/usr/bin/env bash
+# ---------------------------------------------------------------------------
+# claudish-ctl.sh — runtime state switcher + dashboard backing /claudish.
+#
+# The hooks re-read flag files on every message, so switches take effect mid-
+# session where the frozen env cannot:
+#   off-file   (default ~/.claude/claudish-off)    exists -> rewrites paused
+#   mode-file  (default ~/.claude/claudish-mode)   append|replace -> display mode
+#   style-file (default ~/.claude/claudish-style)  tldr|5y -> rewrite style (display hook)
+#   lang-file  (default ~/.claude/claudish-lang)   rewrite language (see lang.sh)
+#   model-file (default ~/.claude/claudish-model)  model (see providers.sh)
+# rewrite.sh reads mode/style; lang/model/off are shared with rewrite-md.sh.
+# They PERSIST across sessions (like the off-file) until cleared — the dashboard
+# flags any that are in force so that persistence is never a silent surprise,
+# and the SessionStart hook (session-notice.sh) announces them on a new session.
+#
+# Usage: claudish-ctl.sh [status|on|off|append|replace|style [name]|language [name]|model [name]|last|cycle|reset]
+#   status        (default) print the dashboard: every setting, its value, and
+#                 WHERE that value comes from (env / a /claudish flag / default)
+#   on            resume rewrites (keeps the current mode)
+#   off           pause rewrites (originals only; also pauses the Markdown hook)
+#   append        original + rewrite appended (and turn on)
+#   replace       rewrite only (and turn on)
+#   style X       rewrite style: "tldr" (short summary) or "5y" (explain like
+#                 I'm five); no name / "default" resets to the plain rewrite.
+#                 A custom CLAUDISH_PROMPT_FILE always wins over styles
+#   language X    rewrite into language X, e.g. "language Brazilian Portuguese"
+#                 (no name / "default" resets to the session/settings language)
+#   model X       use model X for whatever provider is configured (no name /
+#                 "default" resets to the provider default; also turns on)
+#   last          print the ORIGINAL text of the last assistant message
+#   cycle         off -> append -> replace -> off
+#   reset         clear ALL overrides (off/mode/style/language/model) -> env
+#
+# Mutating commands print a one-line confirmation:
+#   "claudish: <off|append|replace> (style: …, language: …, model: …)".
+# Writes fail loudly (exit 1) if a flag file cannot be created/removed.
+# ---------------------------------------------------------------------------
+set -uo pipefail
+
+SELF_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+OFF_FILE="${CLAUDISH_OFF_FILE:-$HOME/.claude/claudish-off}"
+MODE_FILE="${CLAUDISH_MODE_FILE:-$HOME/.claude/claudish-mode}"
+STYLE_FILE="${CLAUDISH_STYLE_FILE:-$HOME/.claude/claudish-style}"
+LANG_FILE="${CLAUDISH_LANG_FILE:-$HOME/.claude/claudish-lang}"
+MODEL_FILE="${CLAUDISH_MODEL_FILE:-$HOME/.claude/claudish-model}"
+
+fail() { printf 'claudish-ctl: %s\n' "$1" >&2; exit 1; }
+
+# Borrow the hooks' own resolvers so the dashboard can't drift from them:
+# providers.sh sets PROVIDER + the provider-default MODEL, lang.sh resolves the
+# effective language. providers.sh is sourced with its model-file override
+# NEUTRALISED (pointed at a path that does not exist) so $MODEL is the clean
+# PROVIDER default — otherwise a `model default` that removes the file this same
+# run would read the file's value back through $MODEL. current_model reads the
+# real file itself, fresh. Both sources are fail-soft.
+_saved_mf="${CLAUDISH_MODEL_FILE:-}"
+export CLAUDISH_MODEL_FILE="$SELF_DIR/.claudish-no-model-file"
+MODEL=""; PROVIDER=""
+dbg() { :; }
+. "$SELF_DIR/providers.sh" 2>/dev/null || true
+if [ -n "$_saved_mf" ]; then export CLAUDISH_MODEL_FILE="$_saved_mf"; else unset CLAUDISH_MODEL_FILE; fi
+claudish_language() { :; }
+. "$SELF_DIR/lang.sh" 2>/dev/null || true
+
+# ---- effective values (each reads its flag file FRESH) --------------------
+current_model() {
+  m=""
+  [ -f "$MODEL_FILE" ] && m="$(head -c 128 "$MODEL_FILE" 2>/dev/null | tr -cd 'A-Za-z0-9:._/-' | head -c 64)"
+  [ -n "$m" ] && { printf '%s' "$m"; return; }
+  printf '%s' "${MODEL:-${CLAUDISH_MODEL:-unknown}}"
+}
+current_lang() {
+  l="$(claudish_language "$PWD" 2>/dev/null)"
+  [ -n "$l" ] && printf '%s' "$l" || printf 'auto'
+}
+current_mode() {
+  m=""
+  [ -f "$MODE_FILE" ] && m="$(cat "$MODE_FILE" 2>/dev/null | tr -d '[:space:]')"
+  case "$m" in append|replace) printf '%s' "$m" ;; *) printf '%s' "${CLAUDISH_MODE:-append}" ;; esac
+}
+current_style() {
+  s=""
+  [ -f "$STYLE_FILE" ] && s="$(cat "$STYLE_FILE" 2>/dev/null | tr -d '[:space:]')"
+  case "$s" in tldr|5y) printf '%s' "$s"; return ;; esac
+  case "${CLAUDISH_STYLE:-}" in tldr|5y) printf '%s' "$CLAUDISH_STYLE" ;; *) printf 'default' ;; esac
+}
+state() { [ -f "$OFF_FILE" ] && printf 'off' || current_mode; }
+
+turn_on() { rm -f "$OFF_FILE" 2>/dev/null || fail "cannot remove $OFF_FILE"; }
+set_mode() { { printf '%s\n' "$1" > "$MODE_FILE"; } 2>/dev/null || fail "cannot write $MODE_FILE"; turn_on; }
+
+# ---- provenance: where does each effective value come from? ---------------
+# "flag" is the one worth flagging — a /claudish file that persists across
+# sessions. The dashboard turns these into a ⚠ line.
+mode_source() {
+  if [ -f "$MODE_FILE" ]; then
+    case "$(cat "$MODE_FILE" 2>/dev/null | tr -d '[:space:]')" in append|replace) echo flag; return ;; esac
+  fi
+  [ -n "${CLAUDISH_MODE+x}" ] && { echo env; return; }
+  echo default
+}
+style_source() {
+  if [ -f "$STYLE_FILE" ]; then
+    case "$(cat "$STYLE_FILE" 2>/dev/null | tr -d '[:space:]')" in tldr|5y) echo flag; return ;; esac
+  fi
+  case "${CLAUDISH_STYLE:-}" in tldr|5y) echo env; return ;; esac
+  echo default
+}
+lang_source() {
+  [ -f "$LANG_FILE" ] && [ -n "$(head -c 64 "$LANG_FILE" 2>/dev/null | tr -d '[:space:]')" ] && { echo flag; return; }
+  [ -n "${CLAUDISH_LANG+x}" ] && { echo env; return; }
+  [ -n "$(claudish_language "$PWD" 2>/dev/null)" ] && { echo settings; return; }
+  echo default
+}
+model_source() {
+  [ -f "$MODEL_FILE" ] && [ -n "$(head -c 128 "$MODEL_FILE" 2>/dev/null | tr -d '[:space:]')" ] && { echo flag; return; }
+  [ -n "${CLAUDISH_MODEL+x}" ] && { echo env; return; }
+  echo provider
+}
+
+WARN=0  # set when any value is a persisting /claudish override
+
+status_label() {
+  case "$(state)" in
+    off)     _mean="originals only" ;;
+    replace) _mean="rewrite only" ;;
+    *)       _mean="original + rewrite" ;;
+  esac
+  if [ -f "$OFF_FILE" ]; then
+    WARN=1; printf '⚠ /claudish off — %s; persists across sessions' "$_mean"; return
+  fi
+  case "$(mode_source)" in
+    flag) WARN=1; printf '⚠ /claudish — %s; beats env, persists across sessions' "$_mean" ;;
+    env)  printf 'env CLAUDISH_MODE — %s' "$_mean" ;;
+    *)    printf 'default — %s' "$_mean" ;;
+  esac
+}
+style_label() {
+  case "$(style_source)" in
+    flag) WARN=1; printf '⚠ /claudish — beats env CLAUDISH_STYLE, persists across sessions' ;;
+    env)  printf 'env CLAUDISH_STYLE' ;;
+    *)    printf 'default — plain-language rewrite' ;;
+  esac
+}
+language_label() {
+  case "$(lang_source)" in
+    flag)     WARN=1; printf '⚠ /claudish — beats env & settings, persists across sessions' ;;
+    env)      printf 'env CLAUDISH_LANG' ;;
+    settings) printf 'your .claude/settings.json language' ;;
+    *)        printf 'default — keeps each message'\''s own language' ;;
+  esac
+}
+model_label() {
+  case "$(model_source)" in
+    flag)     WARN=1; printf '⚠ /claudish — beats env CLAUDISH_MODEL, persists across sessions' ;;
+    env)      printf 'env CLAUDISH_MODEL' ;;
+    *)        printf '%s provider default' "${PROVIDER:-ollama}" ;;
+  esac
+}
+provider_label() { [ -n "${CLAUDISH_PROVIDER+x}" ] && printf 'env CLAUDISH_PROVIDER' || printf 'default'; }
+
+dashboard() {
+  # Compute labels first (they set WARN as a side effect).
+  _sl="$(status_label)"; _yl="$(style_label)"; _ll="$(language_label)"; _ml="$(model_label)"; _pl="$(provider_label)"
+  printf '\n  claudish · plain-language rewrite of each assistant message\n\n'
+  printf '  %-9s %-16s · %s\n' 'status'   "$(state)"            "$_sl"
+  printf '  %-9s %-16s · %s\n' 'style'    "$(current_style)"    "$_yl"
+  printf '  %-9s %-16s · %s\n' 'language' "$(current_lang)"     "$_ll"
+  printf '  %-9s %-16s · %s\n' 'model'    "$(current_model)"    "$_ml"
+  printf '  %-9s %-16s · %s\n' 'provider' "${PROVIDER:-ollama}" "$_pl"
+  printf '\n  change   /claudish on · off · append · replace · style <tldr|5y> · language <name> · model <name>\n'
+  printf '  other    /claudish last · cycle · reset (clear all overrides) · status\n'
+  if [ "$WARN" = "1" ]; then
+    printf '\n  ⚠ lines above are /claudish overrides in ~/.claude/claudish-* that persist\n'
+    printf '    across sessions. Reset one with its `default` form, or all with /claudish reset.\n'
+  fi
+  printf '\n'
+}
+
+cmd="${1:-status}"
+
+# Read-only views print the dashboard and exit; `last` prints a transcript.
+case "$cmd" in
+  status|menu|help|dashboard|"") dashboard; exit 0 ;;
+  last)
+    # The rewrite is display-only: transcripts always keep Claude's original
+    # text. Transcripts live under ~/.claude/projects/<encoded cwd>/, so scope
+    # the search to the CURRENT project first (the command runs in the session's
+    # cwd) and take the most recently touched transcript there — with several
+    # sessions open on the SAME project that is still the best available guess.
+    # Fall back to all projects when the encoded directory does not exist.
+    proj="$(printf '%s' "$PWD" | sed 's/[^A-Za-z0-9]/-/g')"
+    tp="$(ls -t "$HOME/.claude/projects/$proj"/*.jsonl 2>/dev/null | head -n1)"
+    [ -n "$tp" ] || tp="$(ls -t "$HOME/.claude/projects"/*/*.jsonl 2>/dev/null | head -n1)"
+    [ -n "$tp" ] || { printf 'claudish-ctl: no session transcript found\n' >&2; exit 1; }
+    jq -rs '
+      [ .[]
+        | select(.type=="assistant" and .isSidechain!=true)
+        | [.message.content[]? | select(.type=="text") | .text]
+        | join("\n\n")
+        | select(length>0) ]
+      | last // "claudish-ctl: no assistant message in the transcript yet"
+    ' "$tp" 2>/dev/null || { printf 'claudish-ctl: could not parse %s\n' "$tp" >&2; exit 1; }
+    exit 0
+    ;;
+esac
+
+# Mutating commands.
+case "$cmd" in
+  on)      turn_on ;;
+  off)     { : > "$OFF_FILE"; } 2>/dev/null || fail "cannot create $OFF_FILE" ;;
+  append)  set_mode append ;;
+  replace) set_mode replace ;;
+  style)
+    s="$(printf '%s' "${2:-}" | tr -d '[:space:]')"
+    case "$s" in
+      ''|default|Default) rm -f "$STYLE_FILE" 2>/dev/null || fail "cannot remove $STYLE_FILE" ;;
+      tldr|5y)            { printf '%s\n' "$s" > "$STYLE_FILE"; } 2>/dev/null || fail "cannot write $STYLE_FILE" ;;
+      *) printf 'claudish-ctl: unknown style "%s" (use tldr|5y|default)\n' "$s" >&2; exit 2 ;;
+    esac
+    turn_on
+    ;;
+  language)
+    # Take the WHOLE remaining argument so multi-word names survive (e.g.
+    # "Brazilian Portuguese"). lang.sh (via _claudish_lang_clean) does the
+    # authoritative normalisation on read, so multibyte names like "简体中文"
+    # survive too; here we only strip newlines and cap the length.
+    shift
+    lang="$(printf '%s' "$*" | tr -d '\r\n' | head -c 64)"
+    case "$lang" in
+      ''|default|Default) rm -f "$LANG_FILE" 2>/dev/null || fail "cannot remove $LANG_FILE" ;;
+      *) { printf '%s\n' "$lang" > "$LANG_FILE"; } 2>/dev/null || fail "cannot write $LANG_FILE" ;;
+    esac
+    turn_on
+    ;;
+  model)
+    # Sanitise to the characters model names use (ollama tags, OpenAI/Anthropic ids).
+    m="$(printf '%s' "${2:-}" | tr -cd 'A-Za-z0-9:._/-' | head -c 64)"
+    case "$m" in
+      ''|default|Default) rm -f "$MODEL_FILE" 2>/dev/null || fail "cannot remove $MODEL_FILE" ;;
+      *) { printf '%s\n' "$m" > "$MODEL_FILE"; } 2>/dev/null || fail "cannot write $MODEL_FILE" ;;
+    esac
+    turn_on
+    ;;
+  reset)   rm -f "$OFF_FILE" "$MODE_FILE" "$STYLE_FILE" "$LANG_FILE" "$MODEL_FILE" 2>/dev/null || fail "cannot remove one or more flag files" ;;
+  cycle)
+    case "$(state)" in
+      off)    set_mode append ;;
+      append) set_mode replace ;;
+      *)      { : > "$OFF_FILE"; } 2>/dev/null || fail "cannot create $OFF_FILE" ;;
+    esac
+    ;;
+  *)
+    printf 'claudish-ctl: unknown command "%s" (use status|on|off|append|replace|style [name]|language [name]|model [name]|last|cycle|reset)\n' "$cmd" >&2
+    exit 2
+    ;;
+esac
+
+printf 'claudish: %s (style: %s, language: %s, model: %s)\n' "$(state)" "$(current_style)" "$(current_lang)" "$(current_model)"

--- a/commands/claudish.md
+++ b/commands/claudish.md
@@ -1,0 +1,15 @@
+---
+description: Show the claudish dashboard, or switch the rewrite on the fly — on, off, append, replace, "style tldr|5y", "language <name>", "model <name>", "last" (reprint the previous original), cycle, or reset. No argument shows the dashboard.
+argument-hint: "[on|off|append|replace|style <tldr|5y|default>|language <name>|model <name>|last|cycle|reset|status]"
+allowed-tools: Bash("${CLAUDE_PLUGIN_ROOT}"/claudish-ctl.sh:*)
+---
+
+Claudish, after applying "$ARGUMENTS": !`"${CLAUDE_PLUGIN_ROOT}/claudish-ctl.sh" $ARGUMENTS`
+
+Decide how to present the script output above, based on "$ARGUMENTS":
+
+- **Empty, "status", "menu", or "help"** — the output is a preformatted dashboard. Show it to the user verbatim inside a fenced code block, unchanged, and add nothing else. (Lines marked ⚠ are `/claudish` overrides that persist across sessions — the dashboard already explains them, so do not restate.)
+- **"last"** — the output is the ORIGINAL text of the last assistant message. Reply with the literal line `<!-- claudish:original -->` as the VERY FIRST line (it tells the display hook not to rewrite this reply, and is stripped from view), then one short intro line (remind the user that ctrl+o shows the whole original chat), then the text verbatim.
+- **Anything else** (on/off/append/replace/style/language/model/cycle/reset) — the output is a one-line state summary (`claudish: <state> (style: …, language: …, model: …)`, where style `tldr` = short summary, `5y` = explain like I'm five, `default` = plain rewrite). Relay it to the user in one short line. If the script printed an error instead, show that.
+
+Do nothing else.

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,5 +1,16 @@
 {
   "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}\"/session-notice.sh",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
     "MessageDisplay": [
       {
         "hooks": [

--- a/lang.sh
+++ b/lang.sh
@@ -42,6 +42,19 @@ _claudish_lang_clean() {
 }
 
 claudish_language() {
+  # Runtime override written by /claudish (claudish-ctl.sh): a file re-read on
+  # every message, so a `/claudish language X` switch takes effect mid-session
+  # where the frozen CLAUDISH_LANG env cannot. It sits ABOVE the env and the
+  # settings files for the same reason the off-file sits above CLAUDISH_ENABLED
+  # — only a per-message file can be flipped without relaunching. `/claudish
+  # language default` removes it and restores the resolution below. The file
+  # persists across sessions (like the off-file); cleaned like every source.
+  _cl_file="${CLAUDISH_LANG_FILE:-${HOME:-}/.claude/claudish-lang}"
+  if [ -f "$_cl_file" ]; then
+    _cl_rv="$(_claudish_lang_clean "$(head -c 64 "$_cl_file" 2>/dev/null)")"
+    if [ -n "$_cl_rv" ]; then printf '%s' "$_cl_rv"; return 0; fi
+  fi
+
   # An explicitly set CLAUDISH_LANG always wins, including an explicitly EMPTY
   # one — the escape hatch for keeping rewrites in English on a session that
   # speaks something else.

--- a/providers.sh
+++ b/providers.sh
@@ -76,6 +76,18 @@ case "$PROVIDER" in
   *)         MODEL="${CLAUDISH_MODEL:-gemma4:26b-mlx}" ;;
 esac
 
+# Runtime model override written by /claudish (claudish-ctl.sh): a file re-read
+# on every message, so a `/claudish model X` switch takes effect mid-session
+# where the frozen CLAUDISH_MODEL env cannot. It wins over the env/default
+# resolved above; `/claudish model default` removes it and restores that.
+# Sanitised to the characters model names use — the value also lands on the
+# request. Provider-agnostic: X is passed to whatever provider is configured.
+_model_file="${CLAUDISH_MODEL_FILE:-${HOME:-}/.claude/claudish-model}"
+if [ -f "$_model_file" ]; then
+  _mf="$(head -c 128 "$_model_file" 2>/dev/null | tr -cd 'A-Za-z0-9:._/-' | head -c 64)"
+  [ -n "$_mf" ] && MODEL="$_mf"
+fi
+
 # Split the "\n<status>" suffix appended by curl -w '\n%{http_code}' off $resp
 # into $http. "000" (no response at all) is normalized to "".
 _llm_split_status() {

--- a/rewrite.sh
+++ b/rewrite.sh
@@ -31,9 +31,21 @@
 #                                          ~/.claude/claudish-off) — lets a
 #                                          hotkey/script toggle mid-session
 #   CLAUDISH_MODE      append|replace display strategy (default append)
+#   CLAUDISH_STYLE     tldr|5y        rewrite-style preset replacing the base
+#                                          prompt: "tldr" = a clearly shorter
+#                                          summary; "5y" = explain like I'm
+#                                          five. Unset/other = the default
+#                                          plain-language rewrite. A usable
+#                                          CLAUDISH_PROMPT_FILE wins over any
+#                                          style (custom prompt > style >
+#                                          built-in); the language line still
+#                                          applies. Switch it live with
+#                                          /claudish style (a flag file,
+#                                          CLAUDISH_STYLE_FILE, overrides this)
 #   CLAUDISH_PROMPT_FILE <path>       file holding a replacement rewrite prompt
 #                                          (whole prompt, not merged; empty or
-#                                          unreadable -> built-in default)
+#                                          unreadable -> built-in default,
+#                                          overriding any CLAUDISH_STYLE)
 #   CLAUDISH_LANG      <language>     language to rewrite into, e.g. "Esperanto".
 #                                          Unset falls back to the session's
 #                                          `language` setting from
@@ -69,6 +81,29 @@ ENABLED="${CLAUDISH_ENABLED:-1}"
 # every invocation. Create it to pause rewrites instantly; remove it to resume.
 [ -f "${CLAUDISH_OFF_FILE:-$HOME/.claude/claudish-off}" ] && ENABLED=0
 MODE="${CLAUDISH_MODE:-append}"
+# Runtime display-mode override written by /claudish (claudish-ctl.sh): like the
+# off-file, a file re-read per message flips append<->replace mid-session where
+# the frozen CLAUDISH_MODE env cannot. Only the two known values are honoured;
+# anything else (or no file) leaves the env/default in place.
+_mode_file="${CLAUDISH_MODE_FILE:-$HOME/.claude/claudish-mode}"
+if [ -f "$_mode_file" ]; then
+  case "$(cat "$_mode_file" 2>/dev/null | tr -d '[:space:]')" in
+    append)  MODE=append ;;
+    replace) MODE=replace ;;
+  esac
+fi
+# Rewrite-style preset (display hook only): "tldr" = a clearly shorter summary,
+# "5y" = explain like I'm five. Unset/other = the default plain-language rewrite.
+# Like MODE, the env is the launch default and a flag file overrides it live.
+STYLE=""
+case "${CLAUDISH_STYLE:-}" in tldr|5y) STYLE="$CLAUDISH_STYLE" ;; esac
+_style_file="${CLAUDISH_STYLE_FILE:-$HOME/.claude/claudish-style}"
+if [ -f "$_style_file" ]; then
+  case "$(cat "$_style_file" 2>/dev/null | tr -d '[:space:]')" in
+    tldr) STYLE=tldr ;;
+    5y)   STYLE=5y ;;
+  esac
+fi
 MIN_CHARS="${CLAUDISH_MIN_CHARS:-200}"
 STUB="${CLAUDISH_STUB:-0}"
 LLM_TIMEOUT="${CLAUDISH_TIMEOUT:-45}"
@@ -147,8 +182,26 @@ mkdir -p "$mdir" 2>/dev/null || pass_through
 printf '%s' "$payload" | jq -j '.delta // ""' > "$mdir/$(printf '%08d' "$idx").part" 2>/dev/null || pass_through
 dbg "chunk idx=$idx final=$final mid=$mid mode=$MODE"
 
+# ---- opt-out marker -------------------------------------------------------
+# A message that BEGINS with this marker is never rewritten (used by
+# /claudish last, whose whole point is reprinting an original — rewriting it
+# again would defeat it). The marker itself is stripped from the display.
+SKIP_MARK='<!-- claudish:original -->'
+strip_mark() { s="${1#"$SKIP_MARK"}"; s="${s#$'\n'}"; s="${s#$'\n'}"; printf '%s' "$s"; }
+if [ "$idx" = "0" ]; then
+  case "$(cat "$mdir/00000000.part" 2>/dev/null)" in
+    "$SKIP_MARK"*) : > "$mdir/skip" 2>/dev/null ;;
+  esac
+fi
+
 # ---- non-final chunks ----------------------------------------------------
 if [ "$final" != "true" ]; then
+  # Marked message in append mode: stream it, but hide the marker in chunk 0.
+  if [ -f "$mdir/skip" ] && [ "$MODE" != "replace" ] && [ "$idx" = "0" ]; then
+    out="$BUF_ROOT/$sid.$mid.strip"
+    strip_mark "$(cat "$mdir/00000000.part" 2>/dev/null)" > "$out" 2>/dev/null && emit "$out"
+    pass_through
+  fi
   # append: let the original stream through untouched.
   # replace: suppress the streamed original; the whole rewrite lands on final.
   if [ "$MODE" = "replace" ]; then emit_empty; else pass_through; fi
@@ -165,6 +218,18 @@ prose_len="$(printf '%s' "$full" \
 dbg "final: prose_len=$prose_len min=$MIN_CHARS mode=$MODE full_bytes=${#full}"
 
 cleanup() { rm -rf "$mdir" 2>/dev/null || true; }
+
+# Marked message -> never rewrite; re-show the original without the marker.
+# (replace mode blanked every previous chunk, so it needs the whole message;
+# append mode streamed chunk 0 already stripped, so only the final delta.)
+if [ -f "$mdir/skip" ]; then
+  dbg "skip: original-reprint marker"
+  out="$BUF_ROOT/$sid.$mid.orig"
+  if [ "$MODE" = "replace" ]; then src="$full"; else src="$(cat "$final_part" 2>/dev/null)"; fi
+  cleanup
+  strip_mark "$src" > "$out" 2>/dev/null && emit "$out"
+  pass_through
+fi
 
 # Below threshold -> do not rewrite.
 if [ "${prose_len:-0}" -lt "$MIN_CHARS" ]; then
@@ -183,8 +248,13 @@ fi
 # here needs it. Empty -> the rewrite follows the language of the message, so
 # the label must not claim one either.
 OUT_LANG="$(claudish_language "$cwd")"
-SEP=$'\n\n────────────────────────\n💬 In plain '"${OUT_LANG:-language}"$':\n\n'
-dbg "language=${OUT_LANG:-same as the message (default)}"
+# The label names the style and, when set, the language.
+case "$STYLE" in
+  tldr) SEP=$'\n\n────────────────────────\n'"💬 TL;DR${OUT_LANG:+ in $OUT_LANG}:"$'\n\n' ;;
+  5y)   SEP=$'\n\n────────────────────────\n'"💬 Like you're five${OUT_LANG:+, in $OUT_LANG}:"$'\n\n' ;;
+  *)    SEP=$'\n\n────────────────────────\n💬 In plain '"${OUT_LANG:-language}"$':\n\n' ;;
+esac
+dbg "language=${OUT_LANG:-same as the message (default)} style=${STYLE:-default}"
 
 # ---- obtain the rewrite --------------------------------------------------
 rewrite=""
@@ -199,6 +269,13 @@ else
   # whole prompt). An unset/empty/unreadable file falls back to this default, so
   # a bad path never stops rewrites — it just uses the built-in prompt.
   sys="You rewrite the assistant's message into much simpler, plain language. Write the rewrite in the same language as the message you are rewriting. Keep every fact, name, number, and file path. Use short sentences and everyday words. Leave fenced code blocks unchanged. Output ONLY the rewritten message with no preamble, labels, or commentary."
+  # Style presets replace the BASE prompt only: the language line below still
+  # applies, and a usable CLAUDISH_PROMPT_FILE still replaces everything —
+  # custom prompt > style > built-in.
+  case "$STYLE" in
+    tldr) sys="You rewrite the assistant's message as a SHORT summary in simple, plain language. This is a simplification, NOT a translation: it must be clearly shorter than the original — aim for half its length or less. Keep the key facts, decisions, numbers, and file paths; drop repetitions, hedges, and secondary detail. Keep technical terms, commands, and identifiers in their original form. Omit fenced code blocks (the original text is always in the transcript). Write the rewrite in the same language as the message you are rewriting. Output ONLY the rewritten message with no preamble, labels, or commentary." ;;
+    5y)   sys="You rewrite the assistant's message as if explaining it to a five-year-old: very simple words, short sentences, a friendly tone, and simple comparisons for hard ideas. Keep every important fact, name, number, and file path accurate. Keep technical terms, commands, and identifiers in their original form. Leave fenced code blocks unchanged. Write the rewrite in the same language as the message you are rewriting. Output ONLY the rewritten message with no preamble, labels, or commentary." ;;
+  esac
   # A configured language overrides "same language as the message" — it is the
   # last word in the prompt, and it names the language explicitly. The line goes
   # on BEFORE the prompt-file check on purpose: a usable CLAUDISH_PROMPT_FILE

--- a/session-notice.sh
+++ b/session-notice.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# ---------------------------------------------------------------------------
+# session-notice.sh — SessionStart hook. Announces any /claudish overrides that
+# are still in force at the start of a session.
+#
+# The /claudish flag files persist across sessions by design (so does the
+# off-file). That is convenient but can surprise: a language or model set in an
+# earlier session silently applies to a brand-new one. This hook makes it
+# visible — it prints a one-line systemMessage listing whatever is active, so a
+# new session never applies a leftover override silently. It changes NO state.
+#
+# Fail-open and non-blocking: SessionStart cannot block a session anyway, and on
+# any problem this emits nothing and exits 0.
+#
+# Config:
+#   CLAUDISH_NOTICE 1|0   set 0 to stay silent (shared with the rewrite hooks)
+#   CLAUDISH_OFF_FILE / _MODE_FILE / _LANG_FILE / _MODEL_FILE  override paths
+# ---------------------------------------------------------------------------
+set -uo pipefail
+
+[ "${CLAUDISH_NOTICE:-1}" = "1" ] || exit 0
+command -v jq >/dev/null 2>&1 || exit 0
+
+# SessionStart delivers JSON on stdin; we don't need any of it, but draining the
+# pipe keeps the hook well-behaved.
+cat >/dev/null 2>&1 || true
+
+OFF_FILE="${CLAUDISH_OFF_FILE:-$HOME/.claude/claudish-off}"
+MODE_FILE="${CLAUDISH_MODE_FILE:-$HOME/.claude/claudish-mode}"
+STYLE_FILE="${CLAUDISH_STYLE_FILE:-$HOME/.claude/claudish-style}"
+LANG_FILE="${CLAUDISH_LANG_FILE:-$HOME/.claude/claudish-lang}"
+MODEL_FILE="${CLAUDISH_MODEL_FILE:-$HOME/.claude/claudish-model}"
+
+parts=""
+add() { parts="${parts:+$parts, }$1"; }
+
+[ -f "$OFF_FILE" ] && add "off (rewrites paused)"
+
+if [ -f "$MODE_FILE" ]; then
+  case "$(cat "$MODE_FILE" 2>/dev/null | tr -d '[:space:]')" in
+    append|replace) add "mode=$(cat "$MODE_FILE" 2>/dev/null | tr -d '[:space:]')" ;;
+  esac
+fi
+
+if [ -f "$STYLE_FILE" ]; then
+  case "$(cat "$STYLE_FILE" 2>/dev/null | tr -d '[:space:]')" in
+    tldr|5y) add "style=$(cat "$STYLE_FILE" 2>/dev/null | tr -d '[:space:]')" ;;
+  esac
+fi
+
+if [ -f "$LANG_FILE" ]; then
+  l="$(head -c 64 "$LANG_FILE" 2>/dev/null | tr -d '\r\n' | tr -s ' ')"
+  [ -n "$(printf '%s' "$l" | tr -d '[:space:]')" ] && add "language=$l"
+fi
+
+if [ -f "$MODEL_FILE" ]; then
+  m="$(head -c 128 "$MODEL_FILE" 2>/dev/null | tr -cd 'A-Za-z0-9:._/-' | head -c 64)"
+  [ -n "$m" ] && add "model=$m"
+fi
+
+# Nothing overridden -> stay completely silent.
+[ -n "$parts" ] || exit 0
+
+msg="claudish: overrides from an earlier /claudish are still active — ${parts}. Run /claudish to review, or /claudish reset to clear (set CLAUDISH_NOTICE=0 to silence)."
+jq -n --arg m "$msg" '{systemMessage:$m}' 2>/dev/null || exit 0
+exit 0


### PR DESCRIPTION
Adds a `/claudish` slash command so the settings the plugin already reads at launch can also be switched **mid-session**, plus a dashboard that shows the current state and where each value comes from.

## What it does

```
/claudish                  # dashboard: current state + provenance of each value
/claudish on | off         # resume / pause rewrites (drives the existing off-file)
/claudish append | replace # display mode
/claudish style tldr | 5y  # short summary / explain like I'm five (default = plain rewrite)
/claudish language <name>  # output language (default = env/settings)
/claudish model <name>     # model, both hooks (default = env/provider default)
/claudish last             # reprint the ORIGINAL of the last assistant message
/claudish cycle            # off -> append -> replace -> off
/claudish reset            # clear ALL overrides -> back to env/settings
```

Bare `/claudish` prints a dashboard flagging every value that is a persisting `/claudish` override:

```
  status    replace          · ⚠ /claudish — rewrite only; beats env, persists across sessions
  style     tldr             · ⚠ /claudish — beats env CLAUDISH_STYLE, persists across sessions
  language  French           · ⚠ /claudish — beats env & settings, persists across sessions
  model     gemma4:26b-mlx   · ollama provider default
  provider  ollama           · default
```

## Design

- **Four flag files** under `~/.claude/` (`off`, `mode`, `style`, `lang`, `model`) that the hooks re-read on every message, so a switch beats the launch-frozen env var for the rest of the session — generalising the existing off-file pattern. Each consumer validates its own value; a missing/broken file changes nothing, so the fail-open contract is intact.
- **Persistence is visible, never silent.** Overrides persist across sessions (like the off-file), but the dashboard flags each with ⚠ and a new `SessionStart` hook announces any left active at the top of a new session (gated by `CLAUDISH_NOTICE`; `/claudish reset` clears everything).
- **Style presets** replace only the built-in base prompt (custom prompt > style > built-in); the output language still applies; display hook only. The label follows the style (`💬 TL;DR:`, `💬 Like you're five:`).
- **`/claudish last`** works because the rewrite is display-only: the transcript keeps the original, and the reprint carries a `<!-- claudish:original -->` marker the display hook strips and never rewrites.

## Credit

Ported from @MakhBeth's fork ([MakhBeth/claudish-tldr](https://github.com/MakhBeth/claudish-tldr)) and **#17**, adapted to this repo's provider layer and language resolver and reshaped around the four-file dashboard. The `tldr`/`5y` style presets and the multi-word-language, project-scoped-`last`, and loud-write-failure fixes come from that work. Davide is credited as co-author on the commit. This supersedes #17 — closing that in favour of this branch (note to follow there).

## Testing

- `claudish-ctl.sh`: full subcommand matrix, provenance for env/settings/flag/default sources, `reset`, multi-word language, loud failure on unwritable paths, unknown-arg/style errors.
- `rewrite.sh` (stub): mode-file override, per-style labels, marker skip in append/replace, off-file precedence.
- Real request bodies against a local fake ollama server: `tldr`/`5y` prompts and the language line land in `messages[0]`, `CLAUDISH_PROMPT_FILE` wins over styles, `model=` reaches the request.
- `bash -n` on all scripts; all JSON validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)