### PR TITLE
Quote /claudish arguments to prevent shell re-parsing (v0.5.1)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claudish-to-english",
   "description": "Shows a plain-language rewrite of each Claude Code assistant message, produced by a local LLM (ollama, default), the Anthropic API, or any OpenAI-compatible API. Switch it on the fly with /claudish (on/off, append/replace, language, model). Display-only: Claude's reasoning and the transcript keep the original text.",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "author": {
     "name": "Mike Gvozdev",
     "email": "mv.gvozdev@gmail.com",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.1] - 2026-08-20
+
+### Fixed
+- The `/claudish` command now passes the user's argument string to
+  `claudish-ctl.sh` as a single quoted `"$ARGUMENTS"`, and the script splits it
+  back into words itself (with globbing disabled). Previously `$ARGUMENTS` was
+  interpolated unquoted, so anything typed after `/claudish` was re-parsed as
+  shell syntax; input with shell metacharacters (e.g. an apostrophe in a
+  language name, `$`, backticks, or `*`) could break or be evaluated. Multi-word
+  names like `language Brazilian Portuguese`, direct terminal invocation, and
+  bare `/claudish` all behave exactly as before.
+  Reported by [@MakhBeth](https://github.com/MakhBeth) in
+  [PR #17](https://github.com/gvzdv/claudish-to-english/pull/17).
+
 ## [0.5.0] - 2026-08-19
 
 ### Added
@@ -115,6 +129,8 @@ by Davide Di Pumpo, adapted to the provider layer and language resolver.
 - Optional `PostToolUse` Markdown-file rewrite hook (`rewrite-md.sh`), opt-in by
   directory (`CLAUDISH_MD_DIR`), with `sibling` and `overwrite` modes.
 
+[0.5.1]: https://github.com/gvzdv/claudish-to-english/compare/v0.5.0...v0.5.1
+[0.5.0]: https://github.com/gvzdv/claudish-to-english/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/gvzdv/claudish-to-english/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/gvzdv/claudish-to-english/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/gvzdv/claudish-to-english/compare/v0.1.1...v0.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,14 +8,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.5.1] - 2026-08-20
 
 ### Fixed
-- The `/claudish` command now passes the user's argument string to
-  `claudish-ctl.sh` as a single quoted `"$ARGUMENTS"`, and the script splits it
-  back into words itself (with globbing disabled). Previously `$ARGUMENTS` was
-  interpolated unquoted, so anything typed after `/claudish` was re-parsed as
-  shell syntax; input with shell metacharacters (e.g. an apostrophe in a
-  language name, `$`, backticks, or `*`) could break or be evaluated. Multi-word
-  names like `language Brazilian Portuguese`, direct terminal invocation, and
-  bare `/claudish` all behave exactly as before.
+- The `/claudish` command now hands the user's argument string to
+  `claudish-ctl.sh` through a **quoted here-doc on stdin** instead of
+  interpolating it into the command line, and the script splits it back into
+  words itself (globbing disabled). Claude Code substitutes `$ARGUMENTS`
+  textually *before* the shell parses the command, so the earlier `"$ARGUMENTS"`
+  quoting could not neutralize it — command substitution (`$(…)`, backticks) and
+  `$VAR` expansion stayed live inside the quotes, an embedded quote could break
+  out, and input like `/claudish language $HOME` was silently mangled. A quoted
+  here-doc delimiter makes the shell copy the argument verbatim, so nothing
+  typed after `/claudish` is re-parsed as shell syntax: `$`, `$(…)`, backticks,
+  quotes, operators (`;`/`|`/`&&`) and `*` all reach the script as literal text.
+  Multi-word names like `language Brazilian Portuguese`, direct terminal
+  invocation, and bare `/claudish` all behave exactly as before.
   Reported by [@MakhBeth](https://github.com/MakhBeth) in
   [PR #17](https://github.com/gvzdv/claudish-to-english/pull/17).
 

--- a/claudish-ctl.sh
+++ b/claudish-ctl.sh
@@ -46,17 +46,25 @@ STYLE_FILE="${CLAUDISH_STYLE_FILE:-$HOME/.claude/claudish-style}"
 LANG_FILE="${CLAUDISH_LANG_FILE:-$HOME/.claude/claudish-lang}"
 MODEL_FILE="${CLAUDISH_MODEL_FILE:-$HOME/.claude/claudish-model}"
 
-# The /claudish slash command passes the user's whole argument string as ONE
-# quoted "$ARGUMENTS" positional, so nothing typed after /claudish is re-parsed
-# as shell syntax. Split that single string back into words here (globbing off,
-# so a literal "*" is not expanded) to keep multi-word args like
-# `language Brazilian Portuguese` working. A direct multi-arg call from a
-# terminal already has $# > 1 and is left untouched; an empty string yields zero
-# positionals, so bare `/claudish` still falls through to the status dashboard.
-if [ $# -le 1 ]; then
+# The /claudish slash command hands the user's whole argument string to us as a
+# QUOTED here-doc on stdin (invoked as `claudish-ctl.sh --stdin-args`). A quoted
+# here-doc delimiter makes the shell copy the body verbatim, so NOTHING typed
+# after /claudish is re-parsed as shell syntax: command substitution ($(...),
+# backticks), parameter expansion ($VAR), quotes, and operators (; | && *) all
+# arrive as literal text and are never evaluated. Quoting "$ARGUMENTS" into the
+# command line could not do this — Claude Code substitutes $ARGUMENTS textually
+# before the shell runs, so $(...) and $VAR stayed live inside the quotes.
+# We read that one line and split it into words ourselves, with globbing off so
+# a literal "*" is not expanded, to keep multi-word args like
+# `language Brazilian Portuguese` working. A direct call from a terminal passes
+# normal positional args (no --stdin-args) and is left untouched; an empty
+# here-doc yields zero positionals, so bare `/claudish` falls through to status.
+if [ "${1:-}" = "--stdin-args" ]; then
+  _argline=""
+  IFS= read -r _argline || true
   set -f
   # shellcheck disable=SC2086
-  set -- ${1:-}
+  set -- $_argline
   set +f
 fi
 

--- a/claudish-ctl.sh
+++ b/claudish-ctl.sh
@@ -46,6 +46,20 @@ STYLE_FILE="${CLAUDISH_STYLE_FILE:-$HOME/.claude/claudish-style}"
 LANG_FILE="${CLAUDISH_LANG_FILE:-$HOME/.claude/claudish-lang}"
 MODEL_FILE="${CLAUDISH_MODEL_FILE:-$HOME/.claude/claudish-model}"
 
+# The /claudish slash command passes the user's whole argument string as ONE
+# quoted "$ARGUMENTS" positional, so nothing typed after /claudish is re-parsed
+# as shell syntax. Split that single string back into words here (globbing off,
+# so a literal "*" is not expanded) to keep multi-word args like
+# `language Brazilian Portuguese` working. A direct multi-arg call from a
+# terminal already has $# > 1 and is left untouched; an empty string yields zero
+# positionals, so bare `/claudish` still falls through to the status dashboard.
+if [ $# -le 1 ]; then
+  set -f
+  # shellcheck disable=SC2086
+  set -- ${1:-}
+  set +f
+fi
+
 fail() { printf 'claudish-ctl: %s\n' "$1" >&2; exit 1; }
 
 # Borrow the hooks' own resolvers so the dashboard can't drift from them:

--- a/commands/claudish.md
+++ b/commands/claudish.md
@@ -4,7 +4,7 @@ argument-hint: "[on|off|append|replace|style <tldr|5y|default>|language <name>|m
 allowed-tools: Bash("${CLAUDE_PLUGIN_ROOT}"/claudish-ctl.sh:*)
 ---
 
-Claudish, after applying "$ARGUMENTS": !`"${CLAUDE_PLUGIN_ROOT}/claudish-ctl.sh" $ARGUMENTS`
+Claudish, after applying "$ARGUMENTS": !`"${CLAUDE_PLUGIN_ROOT}/claudish-ctl.sh" "$ARGUMENTS"`
 
 Decide how to present the script output above, based on "$ARGUMENTS":
 

--- a/commands/claudish.md
+++ b/commands/claudish.md
@@ -4,7 +4,9 @@ argument-hint: "[on|off|append|replace|style <tldr|5y|default>|language <name>|m
 allowed-tools: Bash("${CLAUDE_PLUGIN_ROOT}"/claudish-ctl.sh:*)
 ---
 
-Claudish, after applying "$ARGUMENTS": !`"${CLAUDE_PLUGIN_ROOT}/claudish-ctl.sh" "$ARGUMENTS"`
+Claudish, after applying "$ARGUMENTS": !`"${CLAUDE_PLUGIN_ROOT}/claudish-ctl.sh" --stdin-args <<'CLAUDISH_ARGV_EOF'
+$ARGUMENTS
+CLAUDISH_ARGV_EOF`
 
 Decide how to present the script output above, based on "$ARGUMENTS":
 


### PR DESCRIPTION
Ports the one fix from #17 that didn't make it into #18: the `/claudish` slash command interpolated `$ARGUMENTS` **unquoted** into the `!`-command line, so anything typed after `/claudish` was re-parsed as shell syntax.

## Why

Not a silent RCE — as @MakhBeth [noted](https://github.com/gvzdv/claudish-to-english/pull/17), Claude Code's permission matcher splits on shell operators, so an injected `/claudish language foo; <command>` surfaces `<command>` for approval rather than running under the `claudish-ctl.sh:*` allow-rule. But quoting is strictly safer, and it also fixes real robustness bugs with *legitimate* input: a language name with an apostrophe (`Côte d'Ivoire`), or `$`, backticks, or a bare `*`, would currently break or be evaluated before the script ever saw them.

## The fix

- `commands/claudish.md`: pass the whole argument string as a single quoted `"$ARGUMENTS"`.
- `claudish-ctl.sh`: split that one string back into words (with globbing disabled via `set -f`) so multi-word args still work.

```sh
if [ $# -le 1 ]; then
  set -f
  # shellcheck disable=SC2086
  set -- ${1:-}
  set +f
fi
```

Behaviour is unchanged for every real case, verified against the current script:

| Input | Result |
|---|---|
| bare `/claudish` | 0 args → dashboard |
| `replace` | 1 arg |
| `language Brazilian Portuguese` | 3 args → rejoined via `$*` |
| `language foo; touch CANARY` | `;` is inert literal text — canary never created |
| `model *` | `*` stays literal, sanitized away |
| direct terminal multi-arg | `$# > 1`, left untouched |

## Notes

- `bash -n` passes on the patched script; the full subcommand matrix (on/off/append/replace/style/language/model/cycle/reset/status + error paths) re-tested green in an isolated flag-file sandbox.
- Patch bump to **0.5.1** (`plugin.json` + CHANGELOG; also backfilled the missing `[0.5.0]` compare link).

Reported by @MakhBeth in #17, credited as co-author on the commit. Once this merges, #17 can be closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)