### PR TITLE
feat: CLAUDISH_ANTHROPIC_AUTH=oauth - ride the local Claude Code login (no API key needed)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claudish-to-english",
   "description": "Shows a plain-language rewrite of each Claude Code assistant message, produced by a local LLM (ollama, default), the Anthropic API, or any OpenAI-compatible API. Switch it on the fly with /claudish (on/off, append/replace, language, model). Display-only: Claude's reasoning and the transcript keep the original text.",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "author": {
     "name": "Mike Gvozdev",
     "email": "mv.gvozdev@gmail.com",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to this project are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.0] - 2026-08-26
+
+### Added
+- An **opt-in oauth mode for the anthropic provider**
+  (`CLAUDISH_ANTHROPIC_AUTH=oauth`) that rides the local Claude Code login
+  instead of an API key: the OAuth access token is re-read on **every call**
+  from the macOS login Keychain (item `Claude Code-credentials`) or
+  `~/.claude/.credentials.json` elsewhere, and sent as `Authorization: Bearer`
+  with the `oauth-2025-04-20` beta flag, a `claude-cli` User-Agent, and
+  `x-app: cli` — rewrites then bill to the existing Claude subscription, no
+  separate API billing. Guard rails: the token is **only ever sent to
+  `https://api.anthropic.com`** (the mode refuses a `CLAUDISH_ANTHROPIC_URL`
+  override, so the credential cannot leak to a proxy), a token past its
+  `expiresAt` is discarded rather than sent, an env `ANTHROPIC_API_KEY` is
+  never used as the Bearer token, and every failure keeps the fail-open
+  contract (original text plus the once-per-session notice). **UNOFFICIAL —
+  use at your own risk:** Anthropic has not blessed third-party use of the
+  Claude Code token, so the first successful oauth rewrite of each session
+  says so on screen (`CLAUDISH_NOTICE=0` silences it). Contributed by
+  [@JackBhanded](https://github.com/JackBhanded) in
+  [PR #20](https://github.com/gvzdv/claudish-to-english/pull/20), with the
+  macOS Keychain read by [@hanjoonchoe](https://github.com/hanjoonchoe).
+
 ## [0.6.0] - 2026-08-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -346,7 +346,8 @@ export ANTHROPIC_API_KEY=__SECRET__
 export CLAUDISH_MODEL=claude-haiku-4-5      # the default; override to taste
 
 # Anthropic — no API key: ride the Claude Code login you're already using.
-# Re-reads the OAuth access token from ~/.claude/.credentials.json on every
+# Re-reads the OAuth access token from the macOS login Keychain (item
+# `Claude Code-credentials`), or ~/.claude/.credentials.json elsewhere, on every
 # call (Claude Code keeps it fresh while running, and these hooks only run
 # while it runs), and authenticates with Authorization: Bearer + the
 # oauth-2025-04-20 beta flag instead of x-api-key. Rewrites then ride your

--- a/README.md
+++ b/README.md
@@ -342,7 +342,20 @@ export CLAUDISH_MODEL=gemma4:26b-mlx        # the default; any pulled tag works
 
 # Anthropic — Claude Haiku
 export CLAUDISH_PROVIDER=anthropic
-export ANTHROPIC_API_KEY=sk-ant-...
+export ANTHROPIC_API_KEY=__SECRET__
+export CLAUDISH_MODEL=claude-haiku-4-5      # the default; override to taste
+
+# Anthropic — no API key: ride the Claude Code login you're already using.
+# Re-reads the OAuth access token from ~/.claude/.credentials.json on every
+# call (Claude Code keeps it fresh while running, and these hooks only run
+# while it runs), and authenticates with Authorization: Bearer + the
+# oauth-2025-04-20 beta flag instead of x-api-key. Rewrites then ride your
+# Claude subscription — no separate API billing. UNOFFICIAL: Anthropic has
+# not blessed third-party use of the Claude Code token, so this mode may stop
+# working without warning; when it does, the hook fails open (original text,
+# once-per-session notice) like every other failure.
+export CLAUDISH_PROVIDER=anthropic
+export CLAUDISH_ANTHROPIC_AUTH=oauth
 export CLAUDISH_MODEL=claude-haiku-4-5      # the default; override to taste
 
 # OpenAI — GPT-5.6 Luna

--- a/README.md
+++ b/README.md
@@ -342,18 +342,25 @@ export CLAUDISH_MODEL=gemma4:26b-mlx        # the default; any pulled tag works
 
 # Anthropic — Claude Haiku
 export CLAUDISH_PROVIDER=anthropic
-export ANTHROPIC_API_KEY=__SECRET__
+export ANTHROPIC_API_KEY=sk-ant-...
 export CLAUDISH_MODEL=claude-haiku-4-5      # the default; override to taste
 
 # Anthropic — no API key: ride the Claude Code login you're already using.
 # Re-reads the OAuth access token from the macOS login Keychain (item
-# `Claude Code-credentials`), or ~/.claude/.credentials.json elsewhere, on every
-# call (Claude Code keeps it fresh while running, and these hooks only run
-# while it runs), and authenticates with Authorization: Bearer + the
-# oauth-2025-04-20 beta flag instead of x-api-key. Rewrites then ride your
-# Claude subscription — no separate API billing. UNOFFICIAL: Anthropic has
-# not blessed third-party use of the Claude Code token, so this mode may stop
-# working without warning; when it does, the hook fails open (original text,
+# `Claude Code-credentials`), or ~/.claude/.credentials.json elsewhere, on
+# every call (Claude Code keeps it fresh while running, and these hooks only
+# run while it runs; a token past its expiresAt is discarded, not sent), and
+# authenticates with Authorization: Bearer + the oauth-2025-04-20 beta flag
+# instead of x-api-key. Rewrites then ride your Claude subscription — no
+# separate API billing. The token is only ever sent to
+# https://api.anthropic.com: this mode refuses to run with a
+# CLAUDISH_ANTHROPIC_URL override, so the credential cannot leak to a proxy.
+#
+# ⚠️ UNOFFICIAL — USE AT YOUR OWN RISK. Anthropic has not blessed third-party
+# use of the Claude Code token: this mode may stop working without warning,
+# and programmatic use of a subscription credential could put your Claude
+# account at risk. The first rewrite of each session repeats this caution on
+# screen. When the mode breaks, the hook fails open (original text,
 # once-per-session notice) like every other failure.
 export CLAUDISH_PROVIDER=anthropic
 export CLAUDISH_ANTHROPIC_AUTH=oauth

--- a/providers.sh
+++ b/providers.sh
@@ -49,8 +49,12 @@ PROVIDER="${CLAUDISH_PROVIDER:-ollama}"
 OLLAMA="${CLAUDISH_OLLAMA:-http://localhost:11434}"
 # CLAUDISH_ANTHROPIC_AUTH=oauth borrows the Claude Code login: the access token
 # is re-read on EVERY call from the macOS login Keychain, or from
-# ~/.claude/.credentials.json on other platforms (Claude Code
-# refreshes it while running, and this hook only ever fires while it runs).
+# ~/.claude/.credentials.json on other platforms (Claude Code refreshes it
+# while running, and this hook only ever fires while it runs; a token past its
+# expiresAt is discarded rather than sent). UNOFFICIAL — use at your own risk;
+# the hooks say so on screen once per session. The token is only ever sent to
+# https://api.anthropic.com: oauth mode refuses to run with a
+# CLAUDISH_ANTHROPIC_URL override, so the credential cannot leak to a proxy.
 ANTHROPIC_AUTH="${CLAUDISH_ANTHROPIC_AUTH:-}"
 ANTHROPIC_KEY="${CLAUDISH_ANTHROPIC_KEY:-${ANTHROPIC_API_KEY:-}}"
 OPENAI_KEY="${CLAUDISH_OPENAI_KEY:-${OPENAI_API_KEY:-}}"
@@ -116,23 +120,62 @@ llm_complete() {
   hdrfile=""; cfgerr=0
   case "$PROVIDER" in
     anthropic)
-      _oauth_beta=()
+      _oauth_hdrs=()
       if [ "$ANTHROPIC_AUTH" = "oauth" ]; then
-        # oauth mode NEVER uses an env-supplied key: reset before the reads so the
-        # [ -n ] fallback below cannot short-circuit on a stale ANTHROPIC_API_KEY
-        # (which would ride the Bearer header and 401) and every call stays a
-        # fresh token read, as documented.
+        # The subscription token is account-scoped, refreshable, and harder to
+        # revoke than an API key — it must never travel anywhere but Anthropic.
+        # Refuse an overridden base URL outright (a proxy would receive the raw
+        # credential); proxy setups should use an API key instead.
+        if [ "$ANTHROPIC_URL" != "https://api.anthropic.com" ]; then
+          cfgerr=1
+          err="oauth mode sends the Claude Code token only to https://api.anthropic.com, but CLAUDISH_ANTHROPIC_URL is set to ${ANTHROPIC_URL} — unset the URL override or switch to an API key. Nothing was sent"
+          dbg "anthropic oauth: refused non-default URL"
+          return 0
+        fi
+        # oauth mode NEVER uses an env-supplied key: reset before the reads so a
+        # stale ANTHROPIC_API_KEY cannot ride the Bearer header (and 401), and
+        # every call stays a fresh token read, as documented.
         ANTHROPIC_KEY=""
         # macOS keeps the credentials in the login Keychain, not on disk, so the
-        # file read below finds nothing there. `security` ships with the OS.
-        # sed, not jq: the token read must work even where jq is missing.
+        # file read is the fallback there. `security` ships with the OS.
+        _cred=""
         if [ "$(uname -s)" = "Darwin" ]; then
-          ANTHROPIC_KEY="$(security find-generic-password -s 'Claude Code-credentials' -w 2>/dev/null \
-                          | sed -n 's/.*"accessToken":"\([^"]*\)".*/\1/p')"
+          _cred="$(security find-generic-password -s 'Claude Code-credentials' -w 2>/dev/null)"
         fi
-        [ -n "$ANTHROPIC_KEY" ] || \
-          ANTHROPIC_KEY="$(sed -n 's/.*"accessToken":"\([^"]*\)".*/\1/p' \
-                          "$HOME/.claude/.credentials.json" 2>/dev/null)"
+        [ -n "$_cred" ] || _cred="$(cat "${HOME:-}/.claude/.credentials.json" 2>/dev/null)"
+        # Narrow to the claudeAiOauth object before extracting fields, so a
+        # file that grows another section with its own accessToken can never
+        # hand us that token (or mismatch it with our expiresAt). Parameter
+        # expansion, not sed: it must work across pretty-printed lines. The
+        # object holds no nested braces, so the first "}" after the key ends
+        # it; a blob without the key passes through unchanged.
+        case "$_cred" in
+          *'"claudeAiOauth"'*) _cred="${_cred#*\"claudeAiOauth\"}"; _cred="${_cred%%\}*}" ;;
+        esac
+        # sed, not jq: the token read must work even where jq is missing.
+        # Whitespace-tolerant around the colon, so a pretty-printed or
+        # hand-edited credentials file parses the same as the compact JSON
+        # Claude Code writes today.
+        ANTHROPIC_KEY="$(printf '%s' "$_cred" \
+          | sed -n 's/.*"accessToken"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -n1)"
+        _exp="$(printf '%s' "$_cred" \
+          | sed -n 's/.*"expiresAt"[[:space:]]*:[[:space:]]*\([0-9][0-9]*\).*/\1/p' | head -n1)"
+        _cred=""
+        # expiresAt is ms since epoch; 0 or absent means unknown — send anyway
+        # and let a 401 report it. A token Claude Code hasn't refreshed yet (an
+        # idle session, a long tool run) is discarded here instead of burning a
+        # doomed request; 30s of slack covers clock skew and request time. The
+        # 2>/dev/null guards keep a corrupt (non-integer-sized) value fail-open.
+        if [ -n "$ANTHROPIC_KEY" ] && [ "${_exp:-0}" -gt 0 ] 2>/dev/null; then
+          _now="$(date +%s 2>/dev/null)"
+          case "$_now" in
+            *[!0-9]*|'') : ;;  # no usable clock — send and let the API decide
+            *) if [ "$_exp" -le "$(( (_now + 30) * 1000 ))" ] 2>/dev/null; then
+                 dbg "anthropic oauth: token expired (expiresAt=${_exp}ms); discarded"
+                 ANTHROPIC_KEY=""
+               fi ;;
+          esac
+        fi
       fi
       if [ -z "$ANTHROPIC_KEY" ]; then dbg "anthropic: no key"; curl_rc=1; return 0; fi
       # No temperature: current Anthropic models reject sampling parameters.
@@ -142,7 +185,14 @@ llm_complete() {
       if [ "$ANTHROPIC_AUTH" = "oauth" ]; then
         # OAuth tokens ride Authorization: Bearer and need the oauth beta flag.
         hdrfile="$(_llm_key_file "Authorization" "Bearer $ANTHROPIC_KEY")"
-        _oauth_beta=(-H 'anthropic-beta: oauth-2025-04-20')
+        # Also present as the Claude Code CLI (these hooks only ever run inside
+        # one): Anthropic buckets OAuth traffic by User-Agent, and requests
+        # without a claude-cli UA land in an aggressively rate-limited default
+        # bucket. The version is a snapshot, not kept in sync — the bucketing
+        # keys on the product token, not the number.
+        _oauth_hdrs=(-H 'anthropic-beta: oauth-2025-04-20' \
+                     -H 'User-Agent: claude-cli/2.1.247 (external, cli)' \
+                     -H 'x-app: cli')
       else
         hdrfile="$(_llm_key_file "x-api-key" "$ANTHROPIC_KEY")"
       fi
@@ -158,7 +208,7 @@ llm_complete() {
       resp="$(printf '%s' "$req" | curl -sS --max-time "$LLM_TIMEOUT" -w '\n%{http_code}' \
               -K "$hdrfile" -H 'Content-Type: application/json' \
               -H 'anthropic-version: 2023-06-01' \
-              ${_oauth_beta[@]+"${_oauth_beta[@]}"} \
+              ${_oauth_hdrs[@]+"${_oauth_hdrs[@]}"} \
               -X POST "$ANTHROPIC_URL/v1/messages" -d @- 2>/dev/null)"
       curl_rc=$?
       rm -f "$hdrfile" 2>/dev/null
@@ -244,12 +294,16 @@ llm_notice_why() {
   NOTICE_WHY=""
   case "$PROVIDER" in
     anthropic)
-      if [ "$ANTHROPIC_AUTH" = "oauth" ] && [ -z "$ANTHROPIC_KEY" ]; then
-        NOTICE_WHY="could not read the Claude Code access token (macOS login Keychain, or ~/.claude/.credentials.json elsewhere) — check that Claude Code is logged in; rewrites are off"
+      # cfgerr first: oauth mode can refuse before any token is read (URL
+      # override), and that reason must win over the generic no-key lines. In
+      # API-key mode cfgerr only ever arises after a key exists, so the two
+      # conditions cannot both hold and the reorder changes nothing there.
+      if [ "${cfgerr:-0}" = "1" ]; then
+        NOTICE_WHY="${err:-provider configuration error}"
+      elif [ "$ANTHROPIC_AUTH" = "oauth" ] && [ -z "$ANTHROPIC_KEY" ]; then
+        NOTICE_WHY="could not read a fresh Claude Code access token (macOS login Keychain, or ~/.claude/.credentials.json elsewhere) — check that Claude Code is logged in; rewrites are off"
       elif [ -z "$ANTHROPIC_KEY" ]; then
         NOTICE_WHY="no Anthropic API key in this session's environment (set CLAUDISH_ANTHROPIC_KEY or ANTHROPIC_API_KEY), so rewrites are off"
-      elif [ "${cfgerr:-0}" = "1" ]; then
-        NOTICE_WHY="${err:-provider configuration error}"
       elif [ "${truncated:-0}" = "1" ]; then
         NOTICE_WHY="the rewrite hit the ${MAX_TOKENS}-token output cap and was discarded rather than shown half-finished — raise CLAUDISH_MAX_TOKENS"
       elif [ -n "${err:-}" ]; then
@@ -292,4 +346,14 @@ llm_notice_why() {
       fi
       ;;
   esac
+}
+
+# One-line "riding your subscription" caution for oauth mode: prints the text
+# when it applies (anthropic provider in oauth mode), nothing otherwise. The
+# hooks show it once per session next to their existing notice plumbing — the
+# wording lives here so both hooks stay identical.
+llm_oauth_note() {
+  [ "$PROVIDER" = "anthropic" ] || return 0
+  [ "$ANTHROPIC_AUTH" = "oauth" ] || return 0
+  printf '%s' "rewrites are riding your Claude subscription through the local Claude Code login (CLAUDISH_ANTHROPIC_AUTH=oauth). This is UNOFFICIAL — Anthropic has not blessed it, it may stop working at any time, and it could put your Claude account at risk. Use at your own risk"
 }

--- a/providers.sh
+++ b/providers.sh
@@ -48,7 +48,8 @@
 PROVIDER="${CLAUDISH_PROVIDER:-ollama}"
 OLLAMA="${CLAUDISH_OLLAMA:-http://localhost:11434}"
 # CLAUDISH_ANTHROPIC_AUTH=oauth borrows the Claude Code login: the access token
-# is re-read from ~/.claude/.credentials.json on EVERY call (Claude Code
+# is re-read on EVERY call from the macOS login Keychain, or from
+# ~/.claude/.credentials.json on other platforms (Claude Code
 # refreshes it while running, and this hook only ever fires while it runs).
 ANTHROPIC_AUTH="${CLAUDISH_ANTHROPIC_AUTH:-}"
 ANTHROPIC_KEY="${CLAUDISH_ANTHROPIC_KEY:-${ANTHROPIC_API_KEY:-}}"
@@ -117,9 +118,16 @@ llm_complete() {
     anthropic)
       _oauth_beta=()
       if [ "$ANTHROPIC_AUTH" = "oauth" ]; then
+        # macOS keeps the credentials in the login Keychain, not on disk, so the
+        # file read below finds nothing there. `security` ships with the OS.
         # sed, not jq: the token read must work even where jq is missing.
-        ANTHROPIC_KEY="$(sed -n 's/.*"accessToken":"\([^"]*\)".*/\1/p' \
-                        "$HOME/.claude/.credentials.json" 2>/dev/null)"
+        if [ "$(uname -s)" = "Darwin" ]; then
+          ANTHROPIC_KEY="$(security find-generic-password -s 'Claude Code-credentials' -w 2>/dev/null \
+                          | sed -n 's/.*"accessToken":"\([^"]*\)".*/\1/p')"
+        fi
+        [ -n "$ANTHROPIC_KEY" ] || \
+          ANTHROPIC_KEY="$(sed -n 's/.*"accessToken":"\([^"]*\)".*/\1/p' \
+                          "$HOME/.claude/.credentials.json" 2>/dev/null)"
       fi
       if [ -z "$ANTHROPIC_KEY" ]; then dbg "anthropic: no key"; curl_rc=1; return 0; fi
       # No temperature: current Anthropic models reject sampling parameters.
@@ -232,7 +240,7 @@ llm_notice_why() {
   case "$PROVIDER" in
     anthropic)
       if [ "$ANTHROPIC_AUTH" = "oauth" ] && [ -z "$ANTHROPIC_KEY" ]; then
-        NOTICE_WHY="could not read the Claude Code access token from ~/.claude/.credentials.json, so rewrites are off"
+        NOTICE_WHY="could not read the Claude Code access token (macOS login Keychain, or ~/.claude/.credentials.json elsewhere) — check that Claude Code is logged in; rewrites are off"
       elif [ -z "$ANTHROPIC_KEY" ]; then
         NOTICE_WHY="no Anthropic API key in this session's environment (set CLAUDISH_ANTHROPIC_KEY or ANTHROPIC_API_KEY), so rewrites are off"
       elif [ "${cfgerr:-0}" = "1" ]; then

--- a/providers.sh
+++ b/providers.sh
@@ -47,6 +47,10 @@
 
 PROVIDER="${CLAUDISH_PROVIDER:-ollama}"
 OLLAMA="${CLAUDISH_OLLAMA:-http://localhost:11434}"
+# CLAUDISH_ANTHROPIC_AUTH=oauth borrows the Claude Code login: the access token
+# is re-read from ~/.claude/.credentials.json on EVERY call (Claude Code
+# refreshes it while running, and this hook only ever fires while it runs).
+ANTHROPIC_AUTH="${CLAUDISH_ANTHROPIC_AUTH:-}"
 ANTHROPIC_KEY="${CLAUDISH_ANTHROPIC_KEY:-${ANTHROPIC_API_KEY:-}}"
 OPENAI_KEY="${CLAUDISH_OPENAI_KEY:-${OPENAI_API_KEY:-}}"
 OPENAI_URL="${CLAUDISH_OPENAI_URL:-https://api.openai.com/v1}"
@@ -111,12 +115,24 @@ llm_complete() {
   hdrfile=""; cfgerr=0
   case "$PROVIDER" in
     anthropic)
+      _oauth_beta=()
+      if [ "$ANTHROPIC_AUTH" = "oauth" ]; then
+        # sed, not jq: the token read must work even where jq is missing.
+        ANTHROPIC_KEY="$(sed -n 's/.*"accessToken":"\([^"]*\)".*/\1/p' \
+                        "$HOME/.claude/.credentials.json" 2>/dev/null)"
+      fi
       if [ -z "$ANTHROPIC_KEY" ]; then dbg "anthropic: no key"; curl_rc=1; return 0; fi
       # No temperature: current Anthropic models reject sampling parameters.
       req="$(jq -n --arg m "$MODEL" --argjson t "$MAX_TOKENS" --arg s "$_sys" --arg u "$_user" \
             '{model:$m,max_tokens:$t,system:$s,messages:[{role:"user",content:$u}]}' 2>/dev/null)"
       [ -n "$req" ] || return 2
-      hdrfile="$(_llm_key_file "x-api-key" "$ANTHROPIC_KEY")"
+      if [ "$ANTHROPIC_AUTH" = "oauth" ]; then
+        # OAuth tokens ride Authorization: Bearer and need the oauth beta flag.
+        hdrfile="$(_llm_key_file "Authorization" "Bearer $ANTHROPIC_KEY")"
+        _oauth_beta=(-H 'anthropic-beta: oauth-2025-04-20')
+      else
+        hdrfile="$(_llm_key_file "x-api-key" "$ANTHROPIC_KEY")"
+      fi
       if [ -z "$hdrfile" ]; then
         cfgerr=1
         err="could not create a private temp file for the API key under ${TMPDIR:-/tmp} — nothing was sent"
@@ -129,6 +145,7 @@ llm_complete() {
       resp="$(printf '%s' "$req" | curl -sS --max-time "$LLM_TIMEOUT" -w '\n%{http_code}' \
               -K "$hdrfile" -H 'Content-Type: application/json' \
               -H 'anthropic-version: 2023-06-01' \
+              ${_oauth_beta[@]+"${_oauth_beta[@]}"} \
               -X POST "$ANTHROPIC_URL/v1/messages" -d @- 2>/dev/null)"
       curl_rc=$?
       rm -f "$hdrfile" 2>/dev/null
@@ -214,7 +231,9 @@ llm_notice_why() {
   NOTICE_WHY=""
   case "$PROVIDER" in
     anthropic)
-      if [ -z "$ANTHROPIC_KEY" ]; then
+      if [ "$ANTHROPIC_AUTH" = "oauth" ] && [ -z "$ANTHROPIC_KEY" ]; then
+        NOTICE_WHY="could not read the Claude Code access token from ~/.claude/.credentials.json, so rewrites are off"
+      elif [ -z "$ANTHROPIC_KEY" ]; then
         NOTICE_WHY="no Anthropic API key in this session's environment (set CLAUDISH_ANTHROPIC_KEY or ANTHROPIC_API_KEY), so rewrites are off"
       elif [ "${cfgerr:-0}" = "1" ]; then
         NOTICE_WHY="${err:-provider configuration error}"

--- a/providers.sh
+++ b/providers.sh
@@ -118,6 +118,11 @@ llm_complete() {
     anthropic)
       _oauth_beta=()
       if [ "$ANTHROPIC_AUTH" = "oauth" ]; then
+        # oauth mode NEVER uses an env-supplied key: reset before the reads so the
+        # [ -n ] fallback below cannot short-circuit on a stale ANTHROPIC_API_KEY
+        # (which would ride the Bearer header and 401) and every call stays a
+        # fresh token read, as documented.
+        ANTHROPIC_KEY=""
         # macOS keeps the credentials in the login Keychain, not on disk, so the
         # file read below finds nothing there. `security` ships with the OS.
         # sed, not jq: the token read must work even where jq is missing.

--- a/rewrite-md.sh
+++ b/rewrite-md.sh
@@ -224,4 +224,18 @@ fi
 
 mv -f "$tmp" "$target" 2>/dev/null || { rm -f "$tmp" 2>/dev/null; pass_through "atomic mv failed"; }
 dbg "wrote $target (mode=$MD_MODE)"
+
+# Once-per-session oauth caution: oauth mode bills rewrites to the user's
+# Claude subscription through an unofficial mechanism, and a systemMessage is
+# the only on-screen surface this hook has. The marker is shared with the
+# display hook (same root and session id) — one caution per session, not two.
+oauth_noted="$LOG_ROOT/$SID.oauth-noted"
+if [ "$NOTICE" = "1" ] && [ ! -e "$oauth_noted" ]; then
+  _onote="$(llm_oauth_note 2>/dev/null)"
+  if [ -n "$_onote" ]; then
+    : > "$oauth_noted" 2>/dev/null || true
+    jq -n --arg m "claudish-to-english: $_onote. Shown once per session; set CLAUDISH_NOTICE=0 to silence." \
+      '{systemMessage:$m}' 2>/dev/null
+  fi
+fi
 exit 0

--- a/rewrite.sh
+++ b/rewrite.sh
@@ -230,15 +230,30 @@ if [ -z "$rewrite" ]; then
   pass_through
 fi
 
+# ---- once-per-session oauth caution ---------------------------------------
+# oauth mode bills rewrites to the user's Claude subscription through an
+# unofficial mechanism, so the FIRST successful rewrite of a session says so
+# on screen (failures already surface through the notice above). The marker
+# is shared with rewrite-md.sh — one caution per session, not one per hook.
+oauth_note=""
+oauth_noted="$BUF_ROOT/$sid.oauth-noted"
+if [ "$NOTICE" = "1" ] && [ ! -e "$oauth_noted" ]; then
+  _onote="$(llm_oauth_note 2>/dev/null)"
+  if [ -n "$_onote" ]; then
+    : > "$oauth_noted" 2>/dev/null || true
+    oauth_note=$'\n\n'"⚠️ claudish-to-english: $_onote. Shown once per session; set CLAUDISH_NOTICE=0 to silence."
+  fi
+fi
+
 # ---- build displayContent for the final chunk ----------------------------
 out="$BUF_ROOT/$sid.$mid.out"
 if [ "$MODE" = "replace" ]; then
   # Everything before was suppressed; show only the rewrite.
-  printf '%s' "$rewrite" > "$out"
+  printf '%s%s' "$rewrite" "$oauth_note" > "$out"
 else
   # append: keep the streamed original (final chunk = its last delta),
   # then append the simplified version.
-  { cat "$final_part" 2>/dev/null; printf '%s' "$SEP"; printf '%s' "$rewrite"; } > "$out"
+  { cat "$final_part" 2>/dev/null; printf '%s' "$SEP"; printf '%s' "$rewrite"; printf '%s' "$oauth_note"; } > "$out"
 fi
 cleanup
 emit "$out"


### PR DESCRIPTION
This adds an opt-in auth mode to the anthropic provider that removes the last
setup hurdle for most Claude Code users: needing a separate API key (and API
billing) when they already have a Claude subscription right there.

**What it does**

With `CLAUDISH_PROVIDER=anthropic` and `CLAUDISH_ANTHROPIC_AUTH=oauth`,
`providers.sh` skips the API key entirely. On every call it re-reads the OAuth
access token Claude Code maintains in `~/.claude/.credentials.json` and sends
`Authorization: Bearer <token>` plus `anthropic-beta: oauth-2025-04-20`
instead of `x-api-key`. Because the hooks only ever run while Claude Code is
running — and Claude Code refreshes that token itself — the token read is
always fresh; there is no refresh logic to maintain in the plugin.

Net effect: Haiku rewrites billed to the user's existing Claude subscription.
Zero extra setup beyond two env vars, no key management, no second wallet.

**Design notes**

- The token is extracted with `sed`, not `jq`, so the read works even where jq
  is missing (the rest of the pipeline still requires jq, as today).
- Default behavior is byte-for-byte unchanged: the mode is opt-in via the new
  env var; unset keeps the existing `x-api-key` path exactly as-is.
- Fail-open is preserved: unreadable credentials file → empty key → the
  existing no-key path, with a dedicated once-per-session notice
  ("could not read the Claude Code access token…").
- The oauth beta header is attached only in oauth mode, via a bash array that
  is empty otherwise, so the standard curl invocation is untouched.

**Caveat (documented in the README)**

Anthropic has not officially blessed third-party use of the Claude Code
token; the mode may stop working without warning. When it does, the plugin
degrades exactly like any other provider failure: original text on screen,
one notice, nothing broken.

**Tested**

On Windows (Git Bash, curl 8.19, jq 1.8.2), Claude Code with a Max
subscription: direct `llm_complete` calls return HTTP 200 with clean rewrites,
and the full MessageDisplay pipeline renders the appended plain-English block.
Also verified the failure path: empty/missing credentials file produces the
new notice and passes the original text through.

Co-authored with Claude (which also, fittingly, gets its own replies
simplified by this plugin now).


🤖 Generated with [Claude Code](https://claude.com/claude-code)