### PR TITLE
Anthropic oauth mode with macOS Keychain, usage ledger and cap, plus a claude provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to this project are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **Anthropic oauth mode, hardened**: on top of PR #20's
+  `CLAUDISH_ANTHROPIC_AUTH=oauth`, the access token now comes from the macOS
+  login Keychain first (item `Claude Code-credentials`), checked against
+  `expiresAt` before use, falling back to `~/.claude/.credentials.json` on
+  other platforms. Only `accessToken` is extracted; the refresh token never
+  lands in a variable or a file, and the token reaches `curl` only through a
+  private temp file, never on the command line and never logged.
+- A **usage ledger**: every oauth call appends one tab-separated line to
+  `usage.log` under `$CLAUDISH_LOCAL_DIR` (default `~/.claude/claudish-local`)
+  with the epoch, caller, model, HTTP status, token counts, the subscription
+  meters the API returns, and a session id, so usage is auditable without
+  logging any message content.
+- **`CLAUDISH_OAUTH_MAX_UTIL`**: an integer percent cap. Once the last oauth
+  response put the 5-hour subscription window at or above it, rewrites skip
+  and fail open until that window resets, instead of spending past the cap.
+- A **`claude` provider** (`CLAUDISH_PROVIDER=claude`): runs the rewrite
+  through Claude Code itself, headless (`claude -p` on Haiku), using the
+  CLI's own login rather than a borrowed token, as a sanctioned alternative
+  to oauth mode.
+
+Builds on the oauth base from PR #20, contributed by
+[@JackBhanded](https://github.com/JackBhanded) in
+[PR #20](https://github.com/gvzdv/claudish-to-english/pull/20).
+
 ## [0.6.0] - 2026-08-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -466,7 +466,20 @@ export CLAUDISH_MODEL=gemma4:26b-mlx        # the default; any pulled tag works
 
 # Anthropic — Claude Haiku
 export CLAUDISH_PROVIDER=anthropic
-export ANTHROPIC_API_KEY=sk-ant-...
+export ANTHROPIC_API_KEY=__SECRET__
+export CLAUDISH_MODEL=claude-haiku-4-5      # the default; override to taste
+
+# Anthropic — no API key: ride the Claude Code login you're already using.
+# Re-reads the OAuth access token from ~/.claude/.credentials.json on every
+# call (Claude Code keeps it fresh while running, and these hooks only run
+# while it runs), and authenticates with Authorization: Bearer + the
+# oauth-2025-04-20 beta flag instead of x-api-key. Rewrites then ride your
+# Claude subscription — no separate API billing. UNOFFICIAL: Anthropic has
+# not blessed third-party use of the Claude Code token, so this mode may stop
+# working without warning; when it does, the hook fails open (original text,
+# once-per-session notice) like every other failure.
+export CLAUDISH_PROVIDER=anthropic
+export CLAUDISH_ANTHROPIC_AUTH=oauth
 export CLAUDISH_MODEL=claude-haiku-4-5      # the default; override to taste
 
 # OpenAI — GPT-5.6 Luna

--- a/README.md
+++ b/README.md
@@ -423,13 +423,14 @@ frontmatter, so the frontmatter stays on line 1 where parsers expect it.
 
 ## Providers
 
-Rewrites go through one of four providers, selected with `CLAUDISH_PROVIDER`
+Rewrites go through one of five providers, selected with `CLAUDISH_PROVIDER`
 (both hooks share the setting). The default is unchanged from upstream: local
 ollama, nothing leaves your machine.
 
 | Provider | Endpoint | Key | Default model |
 |---|---|---|---|
 | `ollama` (default) | `CLAUDISH_OLLAMA` (`http://localhost:11434`) | none | `gemma4:26b-mlx` |
+| `claude` | Claude Code itself, headless (`claude -p`); the CLI's own login | none | `claude-haiku-4-5` |
 | `codex` | OpenAI codex CLI (`codex exec`) — uses the CLI's own login | none | *(CLI default)* |
 | `anthropic` | `CLAUDISH_ANTHROPIC_URL` (`https://api.anthropic.com`) + `/v1/messages` | `CLAUDISH_ANTHROPIC_KEY` or `ANTHROPIC_API_KEY` | `claude-haiku-4-5` |
 | `openai` | `CLAUDISH_OPENAI_URL` + `/chat/completions` | `CLAUDISH_OPENAI_KEY` or `OPENAI_API_KEY` | `gpt-5.6-luna` |
@@ -466,7 +467,7 @@ export CLAUDISH_MODEL=gemma4:26b-mlx        # the default; any pulled tag works
 
 # Anthropic — Claude Haiku
 export CLAUDISH_PROVIDER=anthropic
-export ANTHROPIC_API_KEY=__SECRET__
+export ANTHROPIC_API_KEY=sk-ant-...
 export CLAUDISH_MODEL=claude-haiku-4-5      # the default; override to taste
 
 # Anthropic — no API key: ride the Claude Code login you're already using.
@@ -493,6 +494,35 @@ export CLAUDISH_PROVIDER=openai
 export CLAUDISH_OPENAI_URL=http://localhost:1234/v1
 export CLAUDISH_MODEL=qwen3-30b
 ```
+
+### Anthropic oauth mode, usage ledger, and the claude provider
+
+`CLAUDISH_ANTHROPIC_AUTH=oauth` reads the access token from the macOS login
+Keychain first (item `Claude Code-credentials`), checking `expiresAt` before
+using it; `~/.claude/.credentials.json` is the fallback on other platforms.
+Only `accessToken` is extracted; the refresh token never lands in a
+variable or a file. The token reaches `curl` only through a `0600` temp file
+used with `curl -K`, never on the command line (visible to other local users
+via `ps`) and never logged; the file is removed on exit and if the hook is
+killed mid-request.
+
+Every oauth call appends one line to a tab-separated usage ledger,
+`usage.log` under `$CLAUDISH_LOCAL_DIR` (default `~/.claude/claudish-local`),
+11 columns in order: epoch, caller, model, HTTP status, input tokens, output
+tokens, 5-hour utilization percent, 7-day utilization percent, 5-hour reset
+epoch, cost, session id. No message content is ever logged, only token
+counts, the subscription meters the API returns, and (on the `claude`
+provider) the cost it reports.
+
+`CLAUDISH_OAUTH_MAX_UTIL` sets an integer percent cap: once the last oauth
+response put the 5-hour subscription window at or above it, rewrites skip
+and fail open (original text, once-per-session notice) until that window
+resets, rather than risk spending past the cap.
+
+`CLAUDISH_PROVIDER=claude` is a second, sanctioned path: it runs the
+rewrite through Claude Code itself, headless (`claude -p` on Haiku), using
+the CLI's own login rather than a borrowed token. It is the supported
+alternative for whoever would rather not run in oauth mode at all.
 
 Notes:
 

--- a/providers.sh
+++ b/providers.sh
@@ -17,6 +17,12 @@
 #
 # Providers (CLAUDISH_PROVIDER):
 #   ollama     (default) local ollama at CLAUDISH_OLLAMA
+#   claude     Claude Code itself, headless (claude -p) on Haiku: the rewrite
+#              prompt becomes the system prompt, the message the only turn.
+#              Uses the CLI's own login, no API key, no borrowed token. Runs
+#              with no setting sources, no tools, no MCP, from an empty
+#              directory, so nothing of your setup leaks in and it cannot
+#              re-enter this hook. (see the oauth mode section in README.md)
 #   codex      the OpenAI codex CLI, non-interactively (codex exec); uses the
 #              CLI's own login, so no API key and no local model server. The
 #              rewrite runs with --sandbox read-only outside any repo.
@@ -57,6 +63,15 @@ OLLAMA="${CLAUDISH_OLLAMA:-http://localhost:11434}"
 # is re-read from ~/.claude/.credentials.json on EVERY call (Claude Code
 # refreshes it while running, and this hook only ever fires while it runs).
 ANTHROPIC_AUTH="${CLAUDISH_ANTHROPIC_AUTH:-}"
+# --- oauth mode on top of PR #20 (see the oauth mode section in README.md) ---
+# CLAUDISH_LOCAL_DIR      state dir: usage ledger, cap marker
+#                         (default ~/.claude/claudish-local)
+# CLAUDISH_OAUTH_MAX_UTIL integer percent. When the last oauth response put the
+#                         5-hour subscription window at or above this, rewrites
+#                         pause until that window resets (unset = no cap).
+LOCAL_DIR="${CLAUDISH_LOCAL_DIR:-${HOME:-}/.claude/claudish-local}"
+OAUTH_MAX_UTIL="${CLAUDISH_OAUTH_MAX_UTIL:-}"
+oauth_expired=0; oauth_paused=""
 ANTHROPIC_KEY="${CLAUDISH_ANTHROPIC_KEY:-${ANTHROPIC_API_KEY:-}}"
 OPENAI_KEY="${CLAUDISH_OPENAI_KEY:-${OPENAI_API_KEY:-}}"
 OPENAI_URL="${CLAUDISH_OPENAI_URL:-https://api.openai.com/v1}"
@@ -83,6 +98,7 @@ fi
 case "$PROVIDER" in
   anthropic) MODEL="${CLAUDISH_MODEL:-claude-haiku-4-5}" ;;
   openai)    MODEL="${CLAUDISH_MODEL:-gpt-5.6-luna}" ;;
+  claude)    MODEL="${CLAUDISH_MODEL:-claude-haiku-4-5}" ;;
   codex)     MODEL="${CLAUDISH_MODEL:-}" ;;  # empty = the codex CLI's configured default
   *)         MODEL="${CLAUDISH_MODEL:-gemma4:26b-mlx}" ;;
 esac
@@ -128,17 +144,119 @@ _llm_key_file() {
   printf '%s' "$_kf"
 }
 
+# Read the Claude Code OAuth token. macOS keeps it in the login Keychain
+# (item "Claude Code-credentials"); ~/.claude/.credentials.json is the
+# fallback for other platforms and is usually stale on a Mac. Only the
+# accessToken is kept; the refresh token never lands in a variable or a file.
+# Sets ANTHROPIC_KEY (empty when unreadable or expired) and oauth_expired.
+_oauth_token() {
+  ANTHROPIC_KEY=""; oauth_expired=0; _exp=""
+  if command -v security >/dev/null 2>&1; then
+    _pair="$(security find-generic-password -s "Claude Code-credentials" -w 2>/dev/null \
+             | jq -r '.claudeAiOauth | "\(.accessToken // "") \(.expiresAt // "")"' 2>/dev/null)"
+    ANTHROPIC_KEY="${_pair%% *}"; _exp="${_pair#* }"
+    [ "$_exp" = "$_pair" ] && _exp=""
+  fi
+  if [ -z "$ANTHROPIC_KEY" ]; then
+    _cred="$HOME/.claude/.credentials.json"
+    ANTHROPIC_KEY="$(sed -n 's/.*"accessToken":"\([^"]*\)".*/\1/p' "$_cred" 2>/dev/null)"
+    _exp="$(sed -n 's/.*"expiresAt":\([0-9]*\).*/\1/p' "$_cred" 2>/dev/null)"
+  fi
+  # expiresAt is epoch milliseconds; compare in seconds.
+  case "$_exp" in
+    ""|*[!0-9]*) ;;
+    *) if [ "${#_exp}" -gt 3 ] && [ "${_exp%???}" -lt "$(date +%s)" ]; then
+         oauth_expired=1; ANTHROPIC_KEY=""; dbg "oauth: token expired"
+       fi ;;
+  esac
+  unset _pair _exp _cred
+}
+
+# "0.22" -> "22" (integer percent); "" -> "".
+_pct() {
+  [ -n "$1" ] || return 0
+  printf '%s' "$1" | awk '{ printf "%d", ($1 * 100) + 0.5 }' 2>/dev/null
+}
+
+_oauth_reset_hhmm() {
+  date -r "$1" '+%H:%M' 2>/dev/null || date -d "@$1" '+%H:%M' 2>/dev/null || printf '%s' "$1"
+}
+
+# Skip the call while the cap marker says the 5-hour window is still over
+# CLAUDISH_OAUTH_MAX_UTIL. Sets oauth_paused and returns 1 to skip.
+_oauth_cap_check() {
+  [ -n "$OAUTH_MAX_UTIL" ] && [ -f "$LOCAL_DIR/paused" ] || return 0
+  _preset=""; _pval=""
+  read -r _preset _pval < "$LOCAL_DIR/paused" 2>/dev/null || true
+  if [ -n "$_pval" ] && [ "$_pval" -lt "$OAUTH_MAX_UTIL" ] 2>/dev/null; then
+    rm -f "$LOCAL_DIR/paused" 2>/dev/null   # written under a lower cap
+    return 0
+  fi
+  if [ "${_preset:-0}" -gt "$(date +%s)" ] 2>/dev/null; then
+    oauth_paused="${_pval}% of the 5-hour window (cap CLAUDISH_OAUTH_MAX_UTIL=${OAUTH_MAX_UTIL}), resets at $(_oauth_reset_hhmm "$_preset")"
+    dbg "oauth: paused until $_preset"
+    return 1
+  fi
+  rm -f "$LOCAL_DIR/paused" 2>/dev/null
+  return 0
+}
+
+# Append one line per oauth call to $LOCAL_DIR/usage.log:
+#   epoch  caller  model  http  in_tokens  out_tokens  5h%  7d%  5h_reset_epoch
+#   cost  session_id
+# 11 tab separated columns; cost stays empty on oauth rows. Rows written before
+# the session_id column existed have 9 or 10 columns, and every reader tolerates
+# them by requiring 11 fields before matching a session.
+# (tab separated). No message content ever lands here: only token counts and
+# the subscription meters the API reports (anthropic-ratelimit-unified-*).
+# Also drops the cap marker when the 5-hour meter crosses the cap. Fail-open.
+_oauth_ledger() {
+  [ -n "${hdrdump:-}" ] && [ -f "$hdrdump" ] || return 0
+  _hl="$(tr -d '\r' < "$hdrdump" 2>/dev/null | tr 'A-Z' 'a-z')"
+  _h5="$(printf '%s\n' "$_hl" | sed -n 's/^anthropic-ratelimit-unified-5h-utilization: *\([0-9.]*\).*/\1/p' | head -1)"
+  _h7="$(printf '%s\n' "$_hl" | sed -n 's/^anthropic-ratelimit-unified-7d-utilization: *\([0-9.]*\).*/\1/p' | head -1)"
+  _r5="$(printf '%s\n' "$_hl" | sed -n 's/^anthropic-ratelimit-unified-5h-reset: *\([0-9]*\).*/\1/p' | head -1)"
+  _in="$(printf '%s' "$resp" | jq -r '.usage.input_tokens // 0' 2>/dev/null)"
+  _out="$(printf '%s' "$resp" | jq -r '.usage.output_tokens // 0' 2>/dev/null)"
+  _p5="$(_pct "$_h5")"; _p7="$(_pct "$_h7")"
+  mkdir -p "$LOCAL_DIR" 2>/dev/null && chmod 700 "$LOCAL_DIR" 2>/dev/null
+  printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t\t%s\n' "$(date +%s)" "${0##*/}" "$MODEL" \
+    "${http:-}" "${_in:-0}" "${_out:-0}" "$_p5" "$_p7" "${_r5:-}" "${sid:-${SID:-}}" \
+    >> "$LOCAL_DIR/usage.log" 2>/dev/null
+  if [ -n "$OAUTH_MAX_UTIL" ] && [ -n "$_p5" ] && [ "$_p5" -ge "$OAUTH_MAX_UTIL" ] 2>/dev/null; then
+    printf '%s %s\n' "${_r5:-0}" "$_p5" > "$LOCAL_DIR/paused" 2>/dev/null
+    dbg "oauth: cap hit ($_p5% >= $OAUTH_MAX_UTIL%)"
+  fi
+  unset _hl _h5 _h7 _r5 _in _out _p5 _p7
+}
+
+# Ledger line for the claude provider: same columns as _oauth_ledger, the
+# subscription meters stay empty (claude -p does not expose them) and the
+# cost claude -p reports lands in the 10th column, ahead of the session id in the 11th.
+_claude_ledger() {
+  _ti="$(printf '%s' "$resp" | jq -r '.usage.input_tokens // 0' 2>/dev/null)"
+  _to="$(printf '%s' "$resp" | jq -r '.usage.output_tokens // 0' 2>/dev/null)"
+  _tc="$(printf '%s' "$resp" | jq -r '.total_cost_usd // empty' 2>/dev/null)"
+  mkdir -p "$LOCAL_DIR" 2>/dev/null && chmod 700 "$LOCAL_DIR" 2>/dev/null
+  printf '%s\t%s\t%s\t%s\t%s\t%s\t\t\t\t%s\t%s\n' "$(date +%s)" "${0##*/}" "$MODEL" \
+    "$([ -n "$rewrite" ] && echo 200 || echo err)" "${_ti:-0}" "${_to:-0}" "${_tc:-}" \
+    "${sid:-${SID:-}}" >> "$LOCAL_DIR/usage.log" 2>/dev/null
+  unset _ti _to _tc
+}
+
 llm_complete() {
   _sys="$1"; _user="$2"
   rewrite=""; curl_rc=0; err=""; resp=""; http=""; finish=""; truncated=0
-  hdrfile=""; cfgerr=0
+  hdrfile=""; hdrdump=""; cfgerr=0
+  # A claude -p child spawned by the claude provider must never rewrite its
+  # own output; with no setting sources it loads no hooks, but stay safe.
+  if [ "${CLAUDISH_CHILD:-}" = "1" ]; then dbg "nested claudish child, skipping"; return 0; fi
   case "$PROVIDER" in
     anthropic)
       _oauth_beta=()
       if [ "$ANTHROPIC_AUTH" = "oauth" ]; then
-        # sed, not jq: the token read must work even where jq is missing.
-        ANTHROPIC_KEY="$(sed -n 's/.*"accessToken":"\([^"]*\)".*/\1/p' \
-                        "$HOME/.claude/.credentials.json" 2>/dev/null)"
+        _oauth_cap_check || { curl_rc=1; return 0; }
+        _oauth_token
       fi
       if [ -z "$ANTHROPIC_KEY" ]; then dbg "anthropic: no key"; curl_rc=1; return 0; fi
       # No temperature: current Anthropic models reject sampling parameters.
@@ -149,6 +267,9 @@ llm_complete() {
         # OAuth tokens ride Authorization: Bearer and need the oauth beta flag.
         hdrfile="$(_llm_key_file "Authorization" "Bearer $ANTHROPIC_KEY")"
         _oauth_beta=(-H 'anthropic-beta: oauth-2025-04-20')
+        # Response headers carry the subscription meters; keep them for the ledger.
+        hdrdump="$(mktemp "${TMPDIR:-/tmp}/claudish-hdr.XXXXXX" 2>/dev/null)" || hdrdump=""
+        [ -n "$hdrdump" ] && _oauth_beta+=(-D "$hdrdump")
       else
         hdrfile="$(_llm_key_file "x-api-key" "$ANTHROPIC_KEY")"
       fi
@@ -160,7 +281,7 @@ llm_complete() {
       # If the hook is killed mid-request the file must not linger in TMPDIR.
       # Single quotes: $hdrfile expands when the trap FIRES, immune to quoting
       # in the path (it is always set — reset to "" at the top of this call).
-      trap 'rm -f "$hdrfile" 2>/dev/null' EXIT
+      trap 'rm -f "$hdrfile" "$hdrdump" 2>/dev/null' EXIT
       resp="$(printf '%s' "$req" | curl -sS --max-time "$LLM_TIMEOUT" -w '\n%{http_code}' \
               -K "$hdrfile" -H 'Content-Type: application/json' \
               -H 'anthropic-version: 2023-06-01' \
@@ -169,6 +290,10 @@ llm_complete() {
       curl_rc=$?
       rm -f "$hdrfile" 2>/dev/null
       _llm_split_status
+      if [ "$ANTHROPIC_AUTH" = "oauth" ]; then
+        _oauth_ledger
+        [ -n "$hdrdump" ] && rm -f "$hdrdump" 2>/dev/null
+      fi
       # Join text blocks: models with thinking enabled emit non-text blocks first.
       rewrite="$(printf '%s' "$resp" | jq -j 'if (.content|type)=="array" then ([.content[] | select(.type=="text") | .text] | join("")) else empty end' 2>/dev/null)"
       err="$(printf '%s' "$resp" | jq -r '.error.message // empty' 2>/dev/null)"
@@ -206,6 +331,48 @@ llm_complete() {
       err="$(printf '%s' "$resp" | jq -r 'if (.error|type)=="object" then (.error.message // empty) else (.error // empty) end' 2>/dev/null)"
       finish="$(printf '%s' "$resp" | jq -r '.choices[0].finish_reason // empty' 2>/dev/null)"
       [ "$finish" = "length" ] && { truncated=1; rewrite=""; }
+      ;;
+    claude)
+      if ! command -v claude >/dev/null 2>&1; then
+        dbg "claude: CLI not found"; curl_rc=1; return 0
+      fi
+      _out="$(mktemp "${TMPDIR:-/tmp}/claudish-claude-out.XXXXXX" 2>/dev/null)" || return 2
+      _errf="$(mktemp "${TMPDIR:-/tmp}/claudish-claude-err.XXXXXX" 2>/dev/null)" || { rm -f "$_out"; return 2; }
+      trap 'rm -f "$_out" "$_errf" 2>/dev/null' EXIT
+      # Headless Claude Code on its own login. No setting sources (so no hooks,
+      # plugins, or MCP servers, which also keeps this hook from re-entering
+      # itself), no tools, no session file, run from an empty directory so no
+      # CLAUDE.md is picked up. The message goes in on stdin, never on argv.
+      # CLAUDECODE is unset because the CLI refuses to start inside another
+      # Claude Code; CLAUDISH_CHILD marks the child for the guard above.
+      # No timeout(1) on stock macOS, so background the call and kill on expiry.
+      ( cd "${TMPDIR:-/tmp}" && printf '%s' "$_user" | CLAUDISH_CHILD=1 env -u CLAUDECODE claude -p \
+          --model "$MODEL" --no-session-persistence --setting-sources "" \
+          --tools "" --strict-mcp-config --output-format json \
+          --system-prompt "$_sys" ) > "$_out" 2>"$_errf" &
+      _pid=$!
+      _t=0
+      while kill -0 "$_pid" 2>/dev/null; do
+        if [ "$_t" -ge "$LLM_TIMEOUT" ]; then
+          kill -TERM "$_pid" 2>/dev/null; wait "$_pid" 2>/dev/null
+          curl_rc=28
+          rm -f "$_out" "$_errf" 2>/dev/null
+          dbg "claude -p timed out after ${LLM_TIMEOUT}s"
+          return 0
+        fi
+        sleep 1; _t=$((_t + 1))
+      done
+      wait "$_pid"; _rc=$?
+      resp="$(cat "$_out" 2>/dev/null)"
+      rewrite="$(printf '%s' "$resp" | jq -j 'select(.is_error != true) | .result // empty' 2>/dev/null)"
+      err="$(printf '%s' "$resp" | jq -r 'select(.is_error == true) | (.result // "claude -p reported an error")' 2>/dev/null)"
+      if [ "$_rc" != "0" ] && [ -z "$err" ]; then
+        err="$(tail -c 400 "$_errf" 2>/dev/null)"
+        err="${err:-claude -p failed with exit $_rc}"
+        rewrite=""
+      fi
+      _claude_ledger
+      rm -f "$_out" "$_errf" 2>/dev/null
       ;;
     codex)
       if ! command -v codex >/dev/null 2>&1; then
@@ -287,10 +454,16 @@ $_user" >/dev/null 2>"$_errf" &
 llm_notice_why() {
   # shellcheck disable=SC2034  # NOTICE_WHY is read by the sourcing scripts
   NOTICE_WHY=""
+  # A nested claude -p child skipped the call on purpose; nothing to report.
+  [ "${CLAUDISH_CHILD:-}" = "1" ] && return 0
   case "$PROVIDER" in
     anthropic)
-      if [ "$ANTHROPIC_AUTH" = "oauth" ] && [ -z "$ANTHROPIC_KEY" ]; then
-        NOTICE_WHY="could not read the Claude Code access token from ~/.claude/.credentials.json, so rewrites are off"
+      if [ "$ANTHROPIC_AUTH" = "oauth" ] && [ -n "$oauth_paused" ]; then
+        NOTICE_WHY="oauth rewrites paused: subscription usage at $oauth_paused"
+      elif [ "$ANTHROPIC_AUTH" = "oauth" ] && [ "$oauth_expired" = "1" ]; then
+        NOTICE_WHY="the Claude Code access token has expired; Claude Code refreshes it on its next request, so rewrites resume by themselves"
+      elif [ "$ANTHROPIC_AUTH" = "oauth" ] && [ -z "$ANTHROPIC_KEY" ]; then
+        NOTICE_WHY="could not read the Claude Code access token (macOS Keychain item \"Claude Code-credentials\", or ~/.claude/.credentials.json elsewhere), so rewrites are off"
       elif [ -z "$ANTHROPIC_KEY" ]; then
         NOTICE_WHY="no Anthropic API key in this session's environment (set CLAUDISH_ANTHROPIC_KEY or ANTHROPIC_API_KEY), so rewrites are off"
       elif [ "${cfgerr:-0}" = "1" ]; then
@@ -318,6 +491,15 @@ llm_notice_why() {
         NOTICE_WHY="the rewrite timed out after ${LLM_TIMEOUT}s — ${TIMEOUT_HINT:-raise the timeout}"
       elif [ "$curl_rc" != "0" ]; then
         NOTICE_WHY="cannot reach ${OPENAI_URL} (curl exit $curl_rc)"
+      fi
+      ;;
+    claude)
+      if ! command -v claude >/dev/null 2>&1; then
+        NOTICE_WHY="the claude CLI is not on PATH (pick another CLAUDISH_PROVIDER), so rewrites are off"
+      elif [ "$curl_rc" = "28" ]; then
+        NOTICE_WHY="the rewrite timed out after ${LLM_TIMEOUT}s — ${TIMEOUT_HINT:-raise the timeout}"
+      elif [ -n "${err:-}" ]; then
+        NOTICE_WHY="claude -p error: ${err}"
       fi
       ;;
     codex)

--- a/providers.sh
+++ b/providers.sh
@@ -53,6 +53,10 @@
 
 PROVIDER="${CLAUDISH_PROVIDER:-ollama}"
 OLLAMA="${CLAUDISH_OLLAMA:-http://localhost:11434}"
+# CLAUDISH_ANTHROPIC_AUTH=oauth borrows the Claude Code login: the access token
+# is re-read from ~/.claude/.credentials.json on EVERY call (Claude Code
+# refreshes it while running, and this hook only ever fires while it runs).
+ANTHROPIC_AUTH="${CLAUDISH_ANTHROPIC_AUTH:-}"
 ANTHROPIC_KEY="${CLAUDISH_ANTHROPIC_KEY:-${ANTHROPIC_API_KEY:-}}"
 OPENAI_KEY="${CLAUDISH_OPENAI_KEY:-${OPENAI_API_KEY:-}}"
 OPENAI_URL="${CLAUDISH_OPENAI_URL:-https://api.openai.com/v1}"
@@ -130,12 +134,24 @@ llm_complete() {
   hdrfile=""; cfgerr=0
   case "$PROVIDER" in
     anthropic)
+      _oauth_beta=()
+      if [ "$ANTHROPIC_AUTH" = "oauth" ]; then
+        # sed, not jq: the token read must work even where jq is missing.
+        ANTHROPIC_KEY="$(sed -n 's/.*"accessToken":"\([^"]*\)".*/\1/p' \
+                        "$HOME/.claude/.credentials.json" 2>/dev/null)"
+      fi
       if [ -z "$ANTHROPIC_KEY" ]; then dbg "anthropic: no key"; curl_rc=1; return 0; fi
       # No temperature: current Anthropic models reject sampling parameters.
       req="$(jq -n --arg m "$MODEL" --argjson t "$MAX_TOKENS" --arg s "$_sys" --arg u "$_user" \
             '{model:$m,max_tokens:$t,system:$s,messages:[{role:"user",content:$u}]}' 2>/dev/null)"
       [ -n "$req" ] || return 2
-      hdrfile="$(_llm_key_file "x-api-key" "$ANTHROPIC_KEY")"
+      if [ "$ANTHROPIC_AUTH" = "oauth" ]; then
+        # OAuth tokens ride Authorization: Bearer and need the oauth beta flag.
+        hdrfile="$(_llm_key_file "Authorization" "Bearer $ANTHROPIC_KEY")"
+        _oauth_beta=(-H 'anthropic-beta: oauth-2025-04-20')
+      else
+        hdrfile="$(_llm_key_file "x-api-key" "$ANTHROPIC_KEY")"
+      fi
       if [ -z "$hdrfile" ]; then
         cfgerr=1
         err="could not create a private temp file for the API key under ${TMPDIR:-/tmp} — nothing was sent"
@@ -148,6 +164,7 @@ llm_complete() {
       resp="$(printf '%s' "$req" | curl -sS --max-time "$LLM_TIMEOUT" -w '\n%{http_code}' \
               -K "$hdrfile" -H 'Content-Type: application/json' \
               -H 'anthropic-version: 2023-06-01' \
+              ${_oauth_beta[@]+"${_oauth_beta[@]}"} \
               -X POST "$ANTHROPIC_URL/v1/messages" -d @- 2>/dev/null)"
       curl_rc=$?
       rm -f "$hdrfile" 2>/dev/null
@@ -272,7 +289,9 @@ llm_notice_why() {
   NOTICE_WHY=""
   case "$PROVIDER" in
     anthropic)
-      if [ -z "$ANTHROPIC_KEY" ]; then
+      if [ "$ANTHROPIC_AUTH" = "oauth" ] && [ -z "$ANTHROPIC_KEY" ]; then
+        NOTICE_WHY="could not read the Claude Code access token from ~/.claude/.credentials.json, so rewrites are off"
+      elif [ -z "$ANTHROPIC_KEY" ]; then
         NOTICE_WHY="no Anthropic API key in this session's environment (set CLAUDISH_ANTHROPIC_KEY or ANTHROPIC_API_KEY), so rewrites are off"
       elif [ "${cfgerr:-0}" = "1" ]; then
         NOTICE_WHY="${err:-provider configuration error}"


### PR DESCRIPTION
## What this adds

Builds on PR #20's `CLAUDISH_ANTHROPIC_AUTH=oauth` (riding the Claude Code
login instead of a separate API key). That commit is included as-is,
cherry-picked unmodified as the first commit on this branch, and this branch
rebases cleanly onto `main` if #20 merges first.

On top of it:

- **Keychain-first token read.** The access token now comes from the macOS
  login Keychain (item `Claude Code-credentials`) first, checked against
  `expiresAt` before use, falling back to `~/.claude/.credentials.json` on
  other platforms (where the Keychain path is unavailable). Only
  `accessToken` is extracted; the refresh token never lands in a variable or
  a file.
- **A usage ledger.** Every oauth call appends one tab-separated line to
  `usage.log` under `$CLAUDISH_LOCAL_DIR` (default
  `~/.claude/claudish-local`): epoch, caller, model, HTTP status, input
  tokens, output tokens, 5-hour utilization percent, 7-day utilization
  percent, 5-hour reset epoch, cost, session id. No message content is ever
  logged, only token counts and the subscription meters the API already
  returns in its response headers.
- **`CLAUDISH_OAUTH_MAX_UTIL`.** An integer percent cap. Once the last oauth
  response put the 5-hour subscription window at or above it, rewrites skip
  and fail open until that window resets, instead of risking a spend past
  the cap.
- **A `claude` provider** (`CLAUDISH_PROVIDER=claude`). Runs the rewrite
  through Claude Code itself, headless (`claude -p` on Haiku), using the
  CLI's own sanctioned login rather than a borrowed token, a supported
  alternative for anyone who would rather not use oauth mode at all.

No version bump: that is the maintainer's call.

## Security notes

- The oauth access token never touches argv or a log. It reaches `curl`
  only through a `0600` temp file used with `curl -K`, removed on exit and
  if the hook is killed mid-request.
- Only `accessToken` is read from the Keychain/credentials blob; the
  refresh token is never extracted, stored, or written to disk.
- The usage ledger logs token counts and API-reported meters only, never
  message content.
- Every failure mode stays fail-open, matching the rest of this plugin: a
  missing or expired token, an unreachable Keychain, a cap hit, or a
  `claude` CLI that isn't on PATH just leaves the original text plus the
  existing once-per-session notice.
- This mode is still unofficial in the sense PR #20's own README text
  already flags: Anthropic has not blessed third-party use of the Claude
  Code token, so it may stop working without warning. The `claude` provider
  is the sanctioned fallback for that case.

## How to test

1. Sign in to Claude Code normally (so the Keychain/credentials file holds a
   live token).
2. `export CLAUDISH_PROVIDER=anthropic CLAUDISH_ANTHROPIC_AUTH=oauth` and
   start a session; assistant messages should show the plain-English
   rewrite as usual.
3. Check `~/.claude/claudish-local/usage.log` after a few messages: one
   line per call, 11 tab-separated columns, no message text.
4. Set `CLAUDISH_OAUTH_MAX_UTIL=1` to force the cap and confirm rewrites
   pause with the once-per-session notice, then resume once the window
   would reset.
5. `export CLAUDISH_PROVIDER=claude` and confirm rewrites still work
   through headless `claude -p`, with cost logged in the ledger's cost
   column.
