### PR TITLE
fix(/claudish): correct the allowed-tools quoting; release 0.7.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claudish-to-english",
   "description": "Shows a plain-language rewrite of each Claude Code assistant message, produced by a local LLM (ollama, default), the Anthropic API, or any OpenAI-compatible API. Switch it on the fly with /claudish (on/off, append/replace, language, model). Display-only: Claude's reasoning and the transcript keep the original text.",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "author": {
     "name": "Mike Gvozdev",
     "email": "mv.gvozdev@gmail.com",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.1] - 2026-08-27
+
+### Fixed
+- `/claudish` no longer fails with `Shell command permission check failed`.
+  The command's `allowed-tools` rule closed its quote in the wrong place —
+  `Bash("${CLAUDE_PLUGIN_ROOT}"/claudish-ctl.sh:*)` — while the injected
+  command quotes the whole path
+  (`"${CLAUDE_PLUGIN_ROOT}/claudish-ctl.sh" --stdin-args …`), so the rule's
+  prefix never matched the command and the call was refused. Bash injected
+  from a slash command is allow-or-fail with no permission prompt to fall back
+  on, which turned the mismatch into a hard error on every invocation. The
+  misplaced quote arrived with the command itself in 0.5.0, so `/claudish` has
+  been unusable in every release since.
+
 ## [0.7.0] - 2026-08-26
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -137,15 +137,15 @@ Directly from this repository (also serves its own marketplace):
 
 ```shell
 /plugin marketplace add gvzdv/claudish-to-english
+```
+```shell
 /plugin install claudish-to-english@gvzdv-plugins
 ```
 
-After review by the Anthropic team, the plugin will be available to install from the community marketplace:
-
-```shell
-/plugin marketplace add anthropics/claude-plugins-community
-/plugin install claudish-to-english@claude-community
-```
+The plugin is `Submitted and pending review` on the Claude Marketplace since August 10.  
+~~After review by the Anthropic team, the plugin will be available to install from the community marketplace:~~  
+~~/plugin marketplace add anthropics/claude-plugins-community~~  
+~~/plugin install claudish-to-english@claude-community~~  
 
 If the install summary says `Run /reload-plugins to activate.`, run that command.
 

--- a/commands/claudish.md
+++ b/commands/claudish.md
@@ -1,7 +1,7 @@
 ---
 description: Show the claudish dashboard, or switch the rewrite on the fly — on, off, append, replace, "style tldr|5y", "language <name>", "model <name>", "last" (reprint the previous original), cycle, or reset. No argument shows the dashboard.
 argument-hint: "[on|off|append|replace|style <tldr|5y|default>|language <name>|model <name>|last|cycle|reset|status]"
-allowed-tools: Bash("${CLAUDE_PLUGIN_ROOT}"/claudish-ctl.sh:*)
+allowed-tools: Bash("${CLAUDE_PLUGIN_ROOT}/claudish-ctl.sh":*)
 ---
 
 Claudish, after applying "$ARGUMENTS": !`"${CLAUDE_PLUGIN_ROOT}/claudish-ctl.sh" --stdin-args <<'CLAUDISH_ARGV_EOF'


### PR DESCRIPTION
## What

`/claudish` failed on every invocation with:

```
Shell command permission check failed for pattern "!`"…/claudish-ctl.sh" --stdin-args <<'CLAUDISH_ARGV_EOF' … `"
```

The `allowed-tools` rule closed its quote in the wrong place:

```
before: Bash("${CLAUDE_PLUGIN_ROOT}"/claudish-ctl.sh:*)
after:  Bash("${CLAUDE_PLUGIN_ROOT}/claudish-ctl.sh":*)
```

The injected command quotes the whole path — `"${CLAUDE_PLUGIN_ROOT}/claudish-ctl.sh" --stdin-args …` — so the rule's prefix never matched. Bash injected from a slash command is allow-or-fail with no permission prompt to fall back on, so the mismatch surfaced as a hard error rather than an approval request.

The misplaced quote arrived with the command itself in 0.5.0 (109cb11), so `/claudish` has been unusable in every release since.

## Verification

Five slash-command variants in a scratch project, each run headlessly:

| `allowed-tools` | command | result |
| --- | --- | --- |
| `Bash("<dir>"/ctl.sh:*)` | heredoc | fail |
| `Bash("<dir>"/ctl.sh:*)` | single line | fail |
| `Bash("<dir>/ctl.sh":*)` | heredoc | ok |
| `Bash(<dir>/ctl.sh:*)` | heredoc | ok |
| `Bash(<dir>/ctl.sh:*)` | single line | ok |

The heredoc is not implicated — quote placement alone decides it. Patching the installed 0.7.0 cache and re-running `/claudish-to-english:claudish status` printed the dashboard, which also confirms `${CLAUDE_PLUGIN_ROOT}` does expand inside `allowed-tools`.

## Why the version bump

The marketplace cache is keyed by version (`cache/gvzdv-plugins/claudish-to-english/0.7.0/`). Without bumping `plugin.json`, anyone already on 0.7.0 keeps the broken command — the fix would not ship.

## Also included

`0937f8d` (community marketplace submission status) was unpushed on main and rides along.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
