### PR TITLE
chore: v0.8.0 — caveman preset and per-style labels

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claudish-to-english",
   "description": "Shows a plain-language rewrite of each Claude Code assistant message, produced by a local LLM (ollama, default), the Anthropic API, or any OpenAI-compatible API. Switch it on the fly with /claudish (on/off, append/replace, language, model). Display-only: Claude's reasoning and the transcript keep the original text.",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "author": {
     "name": "Mike Gvozdev",
     "email": "mv.gvozdev@gmail.com",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.8.0] - 2026-08-27
 
 ### Added
 - A **`caveman` style preset** (`CLAUDISH_STYLE=caveman`, `/claudish style
@@ -227,7 +227,8 @@ by Davide Di Pumpo, adapted to the provider layer and language resolver.
 - Optional `PostToolUse` Markdown-file rewrite hook (`rewrite-md.sh`), opt-in by
   directory (`CLAUDISH_MD_DIR`), with `sibling` and `overwrite` modes.
 
-[Unreleased]: https://github.com/gvzdv/claudish-to-english/compare/v0.7.1...HEAD
+[Unreleased]: https://github.com/gvzdv/claudish-to-english/compare/v0.8.0...HEAD
+[0.8.0]: https://github.com/gvzdv/claudish-to-english/compare/v0.7.1...v0.8.0
 [0.7.1]: https://github.com/gvzdv/claudish-to-english/compare/v0.7.0...v0.7.1
 [0.7.0]: https://github.com/gvzdv/claudish-to-english/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/gvzdv/claudish-to-english/compare/v0.5.1...v0.6.0


### PR DESCRIPTION
Cuts the `Unreleased` section that arrived with #21.

**Why MINOR, not PATCH:** `caveman` is a new user-facing feature, so it belongs in a minor bump — same as 0.6.0 (codex provider) and 0.7.0 (oauth mode). 0.7.1 was fix-only. Nothing in this release is breaking.

## Changes

- `CHANGELOG.md`: `## [Unreleased]` → `## [0.8.0] - 2026-08-27`, plus a `[0.8.0]` comparison link and `[Unreleased]` repointed at `v0.8.0...HEAD`
- `.claude-plugin/plugin.json`: `0.7.1` → `0.8.0`

No other file carries a version string — `marketplace.json` doesn't pin one.

## What 0.8.0 ships (from #21)

- **Added:** the `caveman` style preset
- **Changed:** every style now labels its block with its own emoji and a bold accent word — 💬 In plain **language**:, 📌 **TL;DR**:, 👶 Like you're **five**:, 🦴 **Ugh.** Me say:
- **Fixed:** the session-start notice now reports `style=caveman`; a `language` setting can no longer smuggle a terminal escape sequence onto the screen

## After merge

Tag `v0.8.0` at the **merge commit** (not the bump commit), matching how `v0.7.1` is tagged, so `compare/v0.8.0...HEAD` stays clean for the next cycle.
