### PR TITLE
docs: contributor guide, PR template, CLAUDE.md, and a /release skill

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,0 +1,160 @@
+---
+name: release
+description: Cut a claudish-to-english release — pick the version, move the CHANGELOG's Unreleased section under it, bump plugin.json, open the release PR, then tag the merge commit and create the GitHub release. Use when asked to cut, ship, or publish a release, bump the version, or when changes are sitting under "## [Unreleased]" and need releasing.
+---
+
+# Cut a release
+
+Two phases. **Phase 1** prepares the release and opens a PR. Then you STOP: the
+maintainer reviews and merges. **Phase 2** tags and publishes, and can only run
+after the merge because the tag must point at the merge commit.
+
+If `$1` is a version (`0.9.0`, `v0.9.0` — strip any leading `v`), use it. If not,
+derive it and confirm before writing anything.
+
+## Phase 1 — prepare
+
+### 1. Check the ground
+
+```bash
+git switch main && git pull --ff-only
+git status --short
+jq -r .version .claude-plugin/plugin.json
+sed -n '1,40p' CHANGELOG.md
+```
+
+Stop and report if: the tree is dirty, `main` is not current, or `CHANGELOG.md`
+has no `## [Unreleased]` section with real entries under it. An empty Unreleased
+section means there is nothing to release — say so rather than cutting an empty
+version.
+
+### 2. Pick the version
+
+SemVer at `0.x`, based on what is actually under `## [Unreleased]`:
+
+- **MINOR** (`0.8.0` → `0.9.0`) if there is anything under `### Added`, or a
+  `### Changed` entry that alters behaviour users rely on. New style preset, new
+  provider, new env var.
+- **PATCH** (`0.8.0` → `0.8.1`) only if every entry is under `### Fixed`.
+
+Never hide a feature in a patch. State the version and the reason in one line
+before proceeding.
+
+### 3. Edit the two files
+
+Only these two carry a version. `marketplace.json` does not pin one — leave it.
+
+**`CHANGELOG.md`** — three edits:
+
+1. `## [Unreleased]` → `## [<version>] - <today, YYYY-MM-DD>`.
+   Get today's date with `date +%F`; do not guess it.
+2. Add a comparison link ref in the block at the bottom, directly above the
+   previous version's line:
+   `[<version>]: https://github.com/gvzdv/claudish-to-english/compare/v<previous>...v<version>`
+3. Repoint the Unreleased ref:
+   `[Unreleased]: https://github.com/gvzdv/claudish-to-english/compare/v<version>...HEAD`
+
+Leave the `[Unreleased]` *ref* in place but do **not** re-add an empty
+`## [Unreleased]` heading — this repo adds that heading only when there is
+something to put under it.
+
+While you are in the file, tidy the prose of the entries if they read like PR
+descriptions rather than changelog entries, but do not change their meaning or
+drop anything.
+
+**`.claude-plugin/plugin.json`** — bump `"version"`. Edit the string in place so
+key order and formatting survive; do not round-trip the file through a JSON
+serialiser.
+
+### 4. Verify before committing
+
+```bash
+jq empty .claude-plugin/plugin.json && jq -r .version .claude-plugin/plugin.json
+for f in *.sh; do bash -n "$f" || echo "FAIL $f"; done
+```
+
+Then confirm every `## [x]` heading has a matching `[x]:` ref and there are no
+orphans:
+
+```bash
+python3 - <<'PY'
+import re, io
+s = io.open('CHANGELOG.md', encoding='utf-8').read()
+heads = re.findall(r'^## \[([^\]]+)\]', s, re.M)
+refs  = re.findall(r'^\[([^\]]+)\]:', s, re.M)
+print("headings without a ref:", [h for h in heads if h not in refs] or "none")
+print("orphaned refs:", [r for r in refs if r not in heads and r != 'Unreleased'] or "none")
+PY
+```
+
+`jq -r .version` must equal the new heading. Show the full `git diff` — it should
+touch exactly two files.
+
+### 5. Branch, commit, PR
+
+```bash
+git switch -c release/<version> origin/main
+git commit -am "chore: v<version> — <one-line summary of what ships>"
+git push -u origin release/<version>
+gh pr create --base main \
+  --title "chore: v<version> — <summary>" \
+  --body-file <a file you write>
+```
+
+The PR body should state why MINOR or PATCH, list the two changed files, and
+summarise what the release ships (drawn from the changelog section).
+
+### 6. Stop
+
+Report the PR URL and say the tag comes after the merge, since it must point at
+the merge commit. **Do not merge the PR yourself** unless the maintainer
+explicitly asks.
+
+## Phase 2 — after the merge
+
+Only once the release PR is merged.
+
+```bash
+git switch main && git pull --ff-only
+git log --oneline -3
+```
+
+Identify the **merge commit** (`Merge pull request #N from gvzdv/release/<version>`).
+Tag that, *not* the `chore:` bump commit — tagging the bump leaves the release
+branch's commits dangling inside `compare/v<version>...HEAD` next cycle.
+
+```bash
+git tag v<version> <merge-commit-sha>
+git push origin v<version>
+```
+
+Verify the tag lands on the right tree before moving on:
+
+```bash
+git log -1 --format='%h %s' v<version>
+git show v<version>:.claude-plugin/plugin.json | jq -r .version   # == <version>
+```
+
+Then create the GitHub release, with notes taken from the CHANGELOG section
+rather than auto-generated — the hand-written entries are the point:
+
+```bash
+gh release create v<version> \
+  --title "v<version> — <summary>" \
+  --notes-file <the extracted CHANGELOG section>
+```
+
+Extract the section by slicing from `## [<version>]` to the next `## [` line.
+
+Report the tag and release URLs.
+
+## Notes
+
+- Tags here are **lightweight** and sit at the release merge commit. `v0.3.0` is
+  the exception (it predates the convention and sits on a bump commit); do not
+  "fix" it.
+- Tags for `v0.4.0`–`v0.7.1` were backfilled, so those releases have tags but no
+  GitHub release objects. That is expected; do not backfill releases unless
+  asked.
+- If a tag already exists for the target version, stop and report it. Never
+  force-move a published tag.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,60 @@
+<!--
+Thanks for the PR. The checklist is short on purpose — every line is something
+that has actually broken here before. Delete any section that does not apply.
+Full detail: CONTRIBUTING.md
+-->
+
+## What this changes
+
+<!-- One or two sentences. What and why. -->
+
+## How you tested it
+
+<!--
+Paste the command and its output. `CLAUDISH_STUB=1` avoids needing a provider:
+
+  BODY=$(python3 -c "print('This is a long assistant message. '*20)")
+  jq -nc --arg d "$BODY" '{message_id:"m1",session_id:"s1",index:0,final:true,delta:$d,cwd:"/tmp"}' \
+  | CLAUDISH_STUB=1 CLAUDISH_STYLE_FILE=/nonexistent CLAUDISH_LANG_FILE=/nonexistent \
+    CLAUDISH_OFF_FILE=/nonexistent CLAUDISH_NOTICE=0 TMPDIR=/tmp/claudish-test \
+    bash rewrite.sh | jq -r '.hookSpecificOutput.displayContent'
+-->
+
+---
+
+## Checklist
+
+- [ ] `bash -n` passes on every script I touched
+- [ ] **Fails open**: bad input, empty payload, and a missing provider each emit
+      nothing and exit 0 — Claude's original text stays on screen
+- [ ] `CHANGELOG.md` entry added under `## [Unreleased]`
+      (`### Added` / `### Changed` / `### Fixed`)
+- [ ] I did **not** bump `.claude-plugin/plugin.json` or create a tag — the
+      maintainer cuts releases
+- [ ] `README.md` updated if anything user-facing changed (new env vars get a row
+      in the Configuration table)
+
+### If you added or changed a style preset
+
+`CLAUDISH_STYLE` is validated by an allowlist in four places. Missing one fails
+silently:
+
+- [ ] `rewrite.sh` — system prompt + on-screen label
+- [ ] `claudish-ctl.sh` — `current_style`, `style_source`, dashboard, validation + error text
+- [ ] `session-notice.sh` — the persisted-override warning
+- [ ] `commands/claudish.md` — `description` and `argument-hint`
+
+### If you changed anything shown on screen
+
+- [ ] No ANSI escape codes. `displayContent` is markdown — use `**bold**`.
+      (Colour codes are palette indices a terminal theme can remap onto a grey,
+      and they leak as raw bytes into piped `claude -p` output.)
+- [ ] Checked in a real session, not just in the emitted JSON
+- [ ] Any value from config or a flag file goes through `lang.sh`'s
+      `_claudish_lang_clean` before being printed
+
+### If you touched `commands/claudish.md`
+
+- [ ] `allowed-tools` still reads
+      `Bash("${CLAUDE_PLUGIN_ROOT}/claudish-ctl.sh":*)` — quote closes **after**
+      the path. The other form breaks every `/claudish` call.

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 .DS_Store
 *.plain.md
+
+# personal, per-machine Claude Code settings (the shared ones live in
+# .claude/skills/ and CLAUDE.md, which ARE tracked)
+.claude/settings.local.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **Contributor and release documentation.** `CONTRIBUTING.md` covers setup,
+  testing a change without a provider (`CLAUDISH_STUB=1`), the rule that
+  outranks everything else (every hook must fail open), and the traps that have
+  caused real regressions here. A pull-request template puts the same checklist
+  in front of every PR, `CLAUDE.md` gives Claude Code the same ground rules
+  automatically, and a `/release` skill executes a release cut in two phases so
+  the version bump, the changelog link refs, and tagging the merge commit stop
+  being things anyone has to remember. `.claude/settings.local.json` is now
+  gitignored; `.claude/skills/` is tracked.
+
 ## [0.8.0] - 2026-08-27
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,113 @@
+# claudish-to-english
+
+A Claude Code plugin: a `MessageDisplay` hook shows a plain-language rewrite of
+each assistant message, produced by a local or remote LLM. **Display-only** —
+Claude's reasoning and the saved transcript always keep the original text.
+
+Plain bash + `jq` + `curl`. No build, no test suite, no dependencies to install.
+
+`CONTRIBUTING.md` is the full version of this file; it is the source of truth if
+the two ever disagree.
+
+## Layout
+
+| File | Role |
+|---|---|
+| `rewrite.sh` | `MessageDisplay` hook — the main event. Buffers streamed chunks, rewrites on the final one |
+| `rewrite-md.sh` | `PostToolUse` hook — rewrites Markdown files (opt-in, off by default) |
+| `claudish-ctl.sh` | backs `/claudish`; writes the `~/.claude/claudish-*` flag files, prints the dashboard |
+| `session-notice.sh` | `SessionStart` hook — warns that flag files from an earlier session are still active |
+| `providers.sh` | provider layer (ollama / anthropic / openai / codex). Sourced by both hooks |
+| `lang.sh` | output-language resolver + the sanitiser for untrusted config values. Sourced by both hooks |
+| `commands/claudish.md` | the `/claudish` slash command |
+| `hooks/hooks.json` | wires the three hooks |
+
+Config precedence is consistent throughout: **flag file > env var > settings
+file > built-in default**. Flag files exist because env vars are frozen at
+session launch and cannot be changed mid-session.
+
+## Non-negotiable: hooks fail open
+
+On *any* problem — provider down, timeout, no `jq`, malformed payload, missing
+file — a hook emits nothing and exits 0, leaving Claude's original text on
+screen. This outranks every other consideration. Never add a code path where a
+failure can swallow or corrupt an assistant message.
+
+When changing a hook, verify it directly. All three must print nothing, exit 0:
+
+```bash
+printf 'not json'                        | bash rewrite.sh; echo "rc=$?"
+printf ''                                | bash rewrite.sh; echo "rc=$?"
+printf '{"session_id":"s","final":true}' | bash rewrite.sh; echo "rc=$?"
+```
+
+## Testing
+
+`CLAUDISH_STUB=1` replaces the LLM call with a deterministic string — enough for
+all display mechanics, no provider needed. Redirect the `*_FILE` variables so
+the developer's own `~/.claude/claudish-*` files do not leak into the test:
+
+```bash
+BODY=$(python3 -c "print('This is a long assistant message. '*20)")
+jq -nc --arg d "$BODY" \
+  '{message_id:"m1",session_id:"s1",index:0,final:true,delta:$d,cwd:"/tmp"}' \
+| CLAUDISH_STUB=1 CLAUDISH_STYLE=caveman \
+  CLAUDISH_STYLE_FILE=/nonexistent CLAUDISH_LANG_FILE=/nonexistent \
+  CLAUDISH_OFF_FILE=/nonexistent CLAUDISH_NOTICE=0 TMPDIR=/tmp/claudish-test \
+  bash rewrite.sh | jq -r '.hookSpecificOutput.displayContent'
+```
+
+Also run `bash -n` on every script touched. `CLAUDISH_DEBUG=1` logs to
+`${TMPDIR:-/tmp}/claudish-to-english/debug.log`.
+
+To exercise the plugin in a real session, point a scratch project's
+`.claude/settings.json` at the checkout **and** set
+`"enabledPlugins": { "claudish-to-english@gvzdv-plugins": false }` — otherwise
+the installed copy and the working copy both fire on the same message and
+whichever writes last wins.
+
+## Repo-specific traps
+
+Each of these has caused a real regression.
+
+**A new style preset touches four readers**, and missing one fails silently:
+`rewrite.sh` (prompt + label), `claudish-ctl.sh` (`current_style`,
+`style_source`, dashboard, validation + error text), `session-notice.sh`
+(persisted-override warning), `commands/claudish.md` (`description`,
+`argument-hint`). Plus `README.md` and `CHANGELOG.md`.
+
+**Never emit ANSI escape codes.** `displayContent` is rendered as markdown —
+use `**bold**`. Colour codes are palette indices a terminal theme may remap onto
+a grey or the background; they also leak as literal bytes into `claude -p`
+output piped to a file; and the hook has no tty on any descriptor (`[ -t 1 ]` is
+always false, `/dev/tty` will not open) so it cannot detect either case.
+
+**`allowed-tools` in `commands/claudish.md`** must be
+`Bash("${CLAUDE_PLUGIN_ROOT}/claudish-ctl.sh":*)` — the quote closes *after* the
+path. The variant with the quote before the slash breaks every `/claudish` call
+with `Shell command permission check failed`. It has regressed twice; do not
+"correct" it back.
+
+**Untrusted config values go through `lang.sh`.** The `language` key comes from
+`.claude/settings*.json`, which travels with a repository and is not necessarily
+the local user's text. Route it through `_claudish_lang_clean` (folds control
+characters to spaces, caps at three words / 30 codepoints) before it reaches a
+prompt or the screen. Never print a raw config value.
+
+**Comments are load-bearing.** This codebase explains *why*, not *what*, and the
+header comment in each script is its real documentation. Match that density and
+update the header when behaviour changes.
+
+## Changelog and releases
+
+Contributors add an entry under `## [Unreleased]` in `CHANGELOG.md` and **never**
+bump `.claude-plugin/plugin.json` or create tags. The maintainer cuts releases.
+
+When making a change, add the `CHANGELOG.md` entry as part of the work — not as
+a follow-up. Use `### Added` / `### Changed` / `### Fixed`, and say *why*, not
+just what.
+
+To cut a release, use the `/release` skill in `.claude/skills/release/`. SemVer
+at `0.x`: MINOR for a new user-facing feature, PATCH for fixes only. Only
+`plugin.json` and `CHANGELOG.md` carry a version. The tag goes on the **merge**
+commit, never the bump commit.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,241 @@
+# Contributing
+
+Thanks for helping out. This plugin is a handful of bash scripts wired to Claude
+Code hooks, so contributing is mostly: change a script, prove it still fails
+open, add a changelog entry.
+
+- [Ground rules](#ground-rules)
+- [Setting up](#setting-up)
+- [Testing a change](#testing-a-change)
+- [Traps specific to this repo](#traps-specific-to-this-repo)
+- [Opening a pull request](#opening-a-pull-request)
+- [Cutting a release (maintainer)](#cutting-a-release-maintainer)
+
+---
+
+## Ground rules
+
+**Every hook must fail open.** This is the one rule that outranks everything
+else. On *any* problem — provider down, timeout, no `jq`, malformed payload,
+missing file — a hook must emit nothing and `exit 0`, which leaves Claude's
+original text on screen. A display hook that can swallow or corrupt an
+assistant's answer is worse than no plugin at all. If you are unsure whether
+your change preserves this, say so in the PR and it will get checked.
+
+**The plugin is display-only.** Claude's own reasoning and the saved transcript
+always keep the original text. Nothing you add should change what Claude
+actually said, or write to the transcript.
+
+**Contributors do not bump the version and do not create tags.** Add your entry
+under `## [Unreleased]` in `CHANGELOG.md` and leave it there. The maintainer
+cuts releases (see [below](#cutting-a-release-maintainer)). This keeps every
+release a single deliberate commit instead of a scatter of half-bumps.
+
+---
+
+## Setting up
+
+You need `bash`, `jq`, and `curl`. For an end-to-end run you also need a
+provider — but for most work you do **not**: `CLAUDISH_STUB=1` replaces the LLM
+call with a deterministic string, which is enough to test all the display
+mechanics.
+
+To try your working copy as a real plugin, point a scratch project's
+`.claude/settings.json` at your checkout and disable the published one so you
+are not running two copies at once:
+
+```jsonc
+{
+  "enabledPlugins": { "claudish-to-english@gvzdv-plugins": false },
+  "env": { "CLAUDISH_STUB": "1", "CLAUDISH_MIN_CHARS": "50", "CLAUDISH_DEBUG": "1" },
+  "hooks": {
+    "MessageDisplay": [
+      { "hooks": [ { "type": "command", "command": "/abs/path/to/rewrite.sh", "timeout": 60 } ] }
+    ]
+  }
+}
+```
+
+Without that `enabledPlugins: false`, both your copy and the installed plugin
+fire on the same message and whichever writes last wins — a genuinely confusing
+way to lose an afternoon.
+
+`CLAUDISH_DEBUG=1` writes to `${TMPDIR:-/tmp}/claudish-to-english/debug.log`.
+
+---
+
+## Testing a change
+
+There is no test suite. Verify by running the hook directly with a synthetic
+payload — every hook reads JSON on stdin and writes JSON on stdout.
+
+**Syntax check everything you touched:**
+
+```bash
+for f in *.sh; do bash -n "$f" || echo "FAIL $f"; done
+```
+
+**Drive the display hook end to end.** Point `TMPDIR` at a scratch directory and
+send the `*_FILE` variables somewhere nonexistent so your own
+`~/.claude/claudish-*` flag files do not leak into the test:
+
+```bash
+BODY=$(python3 -c "print('This is a long assistant message. '*20)")
+jq -nc --arg d "$BODY" \
+  '{message_id:"m1",session_id:"s1",index:0,final:true,delta:$d,cwd:"/tmp"}' \
+| CLAUDISH_STUB=1 CLAUDISH_STYLE=caveman \
+  CLAUDISH_STYLE_FILE=/nonexistent CLAUDISH_LANG_FILE=/nonexistent \
+  CLAUDISH_OFF_FILE=/nonexistent CLAUDISH_NOTICE=0 TMPDIR=/tmp/claudish-test \
+  bash rewrite.sh | jq -r '.hookSpecificOutput.displayContent'
+```
+
+**Prove it still fails open.** Each of these must print nothing and exit 0:
+
+```bash
+printf 'not json'                        | bash rewrite.sh; echo "rc=$?"
+printf ''                                | bash rewrite.sh; echo "rc=$?"
+printf '{"session_id":"s","final":true}' | bash rewrite.sh; echo "rc=$?"   # no message_id
+```
+
+**If you touched anything user-visible on screen, check it in a real session**
+rather than only in the JSON. The terminal renderer is not a pass-through — see
+the ANSI trap below.
+
+---
+
+## Traps specific to this repo
+
+These are all real regressions that have happened. They are cheap to avoid and
+expensive to find.
+
+### A new style preset touches four readers, not one
+
+`CLAUDISH_STYLE` / the style flag file are validated by an allowlist in **four**
+places. Miss one and the failure is silent:
+
+| File | What it does with the value |
+|---|---|
+| `rewrite.sh` | picks the system prompt and the on-screen label |
+| `claudish-ctl.sh` | `current_style`, `style_source`, the dashboard, `/claudish style` validation and its error text |
+| `session-notice.sh` | warns at session start that a persisted style is still active |
+| `commands/claudish.md` | `description` and `argument-hint` |
+
+Plus `README.md` and `CHANGELOG.md`. The `caveman` preset shipped with
+`session-notice.sh` missed, so a style set by `/claudish style` persisted across
+sessions with nothing on screen to say so.
+
+### Never emit ANSI escape codes
+
+`displayContent` is rendered as **markdown**, so use `**bold**` for emphasis —
+not `\033[1;93m`. Raw ANSI is a bad idea here for three separate reasons:
+
+- The 16-colour codes are palette *indices*. A terminal theme may map them onto
+  a grey or onto the background, so the accent can silently vanish (Solarized
+  maps four of the bright slots to monotones).
+- The escapes leak as literal bytes into `claude -p` output piped to a file.
+- The hook has **no tty on any file descriptor** — `[ -t 1 ]` is always false
+  and `/dev/tty` cannot be opened — so it cannot detect either condition and
+  degrade.
+
+The renderer honours SGR codes but strips other control sequences, so this is
+about legibility and piped output, not safety.
+
+### `allowed-tools` quoting in `commands/claudish.md`
+
+The correct line is:
+
+```
+allowed-tools: Bash("${CLAUDE_PLUGIN_ROOT}/claudish-ctl.sh":*)
+```
+
+The quote closes **after** the path. If you see
+`Bash("${CLAUDE_PLUGIN_ROOT}"/claudish-ctl.sh:*)` — quote before the slash —
+that is the bug: the injected command quotes the whole path, so the rule's
+prefix never matches and every `/claudish` call fails with
+`Shell command permission check failed`, with no permission prompt to fall back
+on. This has regressed twice, once through a merge conflict resolution. Do not
+"fix" it back.
+
+### Untrusted config values must go through `lang.sh`
+
+The `language` key is read from `.claude/settings*.json`, and a project's
+settings file travels with the repository — it is not necessarily the local
+user's own text. Anything that reaches a prompt or the screen goes through
+`_claudish_lang_clean`, which folds control characters to spaces and caps the
+value at three words / 30 codepoints. Do not print a raw config value.
+
+### Both hooks share `providers.sh` and `lang.sh`
+
+`rewrite.sh` and `rewrite-md.sh` source both. A change to either affects the
+Markdown hook too, and a missing file must degrade rather than stop rewrites.
+
+---
+
+## Opening a pull request
+
+1. Branch from `main`.
+2. Make the change; keep the surrounding comment style — this codebase explains
+   *why*, not *what*, and the comments are load-bearing documentation.
+3. Add a `CHANGELOG.md` entry under `## [Unreleased]`, using
+   `### Added` / `### Changed` / `### Fixed`. Create the `## [Unreleased]`
+   heading if it is not there. **Do not** touch `.claude-plugin/plugin.json`.
+4. Update `README.md` if you changed anything user-facing — env vars have a row
+   in the [Configuration](README.md#configuration-env-vars) table.
+5. Open the PR. The template will prompt you through the checklist.
+
+Small, focused PRs get reviewed faster. Two unrelated changes are two PRs.
+
+---
+
+## Cutting a release (maintainer)
+
+Versioning is [SemVer](https://semver.org) at `0.x`:
+
+- **MINOR** for a new user-facing feature — a style preset, a provider, a new
+  env var. (0.6.0 codex provider, 0.7.0 oauth mode, 0.8.0 caveman preset.)
+- **PATCH** for fixes only, nothing new. (0.7.1.)
+
+Only two files carry a version: `.claude-plugin/plugin.json` and
+`CHANGELOG.md`. `marketplace.json` does not pin one.
+
+With Claude Code, run `/release <version>` and it does all of this. By hand:
+
+```bash
+# 1. branch
+git switch -c release/0.9.0 origin/main
+
+# 2. CHANGELOG.md: "## [Unreleased]"  ->  "## [0.9.0] - YYYY-MM-DD"
+
+# 3. CHANGELOG.md link refs at the bottom: add the new version, repoint Unreleased
+#    [Unreleased]: https://github.com/gvzdv/claudish-to-english/compare/v0.9.0...HEAD
+#    [0.9.0]:      https://github.com/gvzdv/claudish-to-english/compare/v0.8.0...v0.9.0
+
+# 4. .claude-plugin/plugin.json: bump "version"
+
+# 5. commit, push, PR, review, merge
+git commit -am "chore: v0.9.0 — <one-line summary>"
+gh pr create --base main --title "chore: v0.9.0 — <summary>"
+
+# 6. tag the MERGE COMMIT (not the bump commit), then push the tag
+git switch main && git pull --ff-only
+git tag v0.9.0 <merge-commit-sha>
+git push origin v0.9.0
+
+# 7. GitHub release, notes taken from the CHANGELOG section
+gh release create v0.9.0 --title "v0.9.0 — <summary>" --notes-file <section>
+```
+
+Two details that are easy to get wrong:
+
+- **Tag the merge commit**, not the `chore:` bump commit. Tagging the bump leaves
+  the release-branch commits dangling in `compare/vX...HEAD` next cycle.
+- **Every heading needs a link ref.** After editing, check that the set of
+  `## [x]` headings and the set of `[x]:` refs at the bottom agree.
+
+Sanity check before merging a release PR:
+
+```bash
+jq -r .version .claude-plugin/plugin.json      # matches the new heading
+grep -c '^## \[' CHANGELOG.md                  # one more than last release
+for f in *.sh; do bash -n "$f" || echo FAIL; done
+```

--- a/README.md
+++ b/README.md
@@ -653,6 +653,16 @@ claudish-to-english/
 └── README.md
 ```
 
+## Contributing
+
+Bug reports and PRs welcome. See **[CONTRIBUTING.md](CONTRIBUTING.md)** for how
+to set up a working copy, how to test a change without a provider
+(`CLAUDISH_STUB=1`), the one rule that outranks everything (every hook must
+**fail open**), and the traps that have bitten before — a new style preset
+touches four files, and on-screen text must never use ANSI colour codes.
+
+Add your changelog entry under `## [Unreleased]`; the maintainer cuts releases.
+
 ## License
 
 MIT — see [LICENSE](./LICENSE).


### PR DESCRIPTION
The release process and this repo's non-obvious traps lived only in review comments and in whoever happened to remember them. This writes them down.

## Files

| File | Audience | Why this one |
|---|---|---|
| `CONTRIBUTING.md` | contributors + maintainer | The source of truth. GitHub auto-links it from the "New pull request" page and the repo sidebar. |
| `.github/pull_request_template.md` | contributors | Auto-fills every PR body, so the requirements show up at the moment they're needed instead of in a doc nobody opened. |
| `CLAUDE.md` | Claude Code | Picked up automatically in any session in this repo, so the process is followed without being asked. |
| `.claude/skills/release/SKILL.md` | maintainer | `/release <version>` executes the cut. Two phases — it stops for review before tagging. |

Also: a `Contributing` section in `README.md`, and `.gitignore` now excludes `.claude/settings.local.json` (personal) while keeping `.claude/skills/` tracked.

## The rule that keeps releases clean

> Contributors add an entry under `## [Unreleased]` and never bump `plugin.json` or create tags. The maintainer cuts the release.

## Traps captured — all real regressions from this cycle

- **A new style preset touches four readers**, and missing one fails silently. `session-notice.sh` was missed for `caveman`, so a style set via `/claudish style` persisted across sessions with nothing on screen to say so.
- **Hooks must never emit ANSI.** Colour codes are palette indices a terminal theme can remap onto a grey (Solarized maps four bright slots to monotones), they leak as raw bytes into piped `claude -p` output, and the hook has no tty on any descriptor so it can't detect either case. `displayContent` is markdown — use `**bold**`.
- **`allowed-tools` quoting** in `commands/claudish.md` has regressed twice, once through a merge conflict resolution. Documented with a "don't fix it back" note.
- **Untrusted config values** (`language` from a repo-travelling `settings.json`) must go through `lang.sh`'s cleaner before display.
- **Tag the merge commit, not the bump commit.**

## Verified

Every command in the docs was run verbatim, not just written:

- the three fail-open cases each print nothing and exit 0
- the `CLAUDISH_STUB=1` test command produces `🦴 **Ugh.** Me say:`
- the four provider names match `providers.sh`
- the `README.md#configuration-env-vars` anchor resolves
- the skill's YAML frontmatter parses
- nothing personal is staged — `.claude/settings.local.json` stays untracked
