### PR TITLE
fix: tell the rewrite model whose voice it is reading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   being things anyone has to remember. `.claude/settings.local.json` is now
   gitignored; `.claude/skills/` is tracked.
 
+### Changed
+- **Every rewrite prompt now states whose voice it is reading**: the input is
+  one turn of a conversation, so the model is told that "I"/"me"/"my" are the
+  assistant and "you"/"your" are the user, and that the rewrite must keep that
+  point of view. Without it the pronouns had nothing to anchor to and rewrites
+  could invert the roles — reading "I" as the rewriter, or addressing the
+  assistant instead of the user. The line is added after the
+  `CLAUDISH_PROMPT_FILE` override rather than before it (where the output
+  language sits): a custom prompt legitimately replaces style and language
+  choices, but this is a fact about the input, so it applies to every rewrite —
+  default, style preset, and custom prompt alike.
+
 ## [0.8.0] - 2026-08-27
 
 ### Added

--- a/rewrite.sh
+++ b/rewrite.sh
@@ -19,6 +19,11 @@
 # to rewrite, answer, or repeat the question; only the assistant message is
 # rewritten. Missing/unreadable transcript -> no context, still rewrites.
 #
+# Every rewrite is also told WHOSE voice it is reading: the input is one turn of
+# a conversation, so "I" is the assistant and "you" is the user. That framing is
+# added even over CLAUDISH_PROMPT_FILE, because it is a fact about the input
+# rather than a style choice.
+#
 # FAIL-OPEN CONTRACT: on ANY problem (disabled, no jq, parse error, LLM down,
 # timeout, empty rewrite) we emit nothing and exit 0, which leaves Claude's
 # ORIGINAL text on screen. A display hook must never be able to swallow the
@@ -305,6 +310,14 @@ else
       dbg "CLAUDISH_PROMPT_FILE set but empty/unreadable ($CLAUDISH_PROMPT_FILE); using default prompt"
     fi
   fi
+
+  # Frames the INPUT for every rewrite: the text is one turn of a conversation,
+  # so its pronouns are anchored to speakers the model cannot see. Without this,
+  # "I" drifts onto the rewriter and "you" onto the assistant, and the rewrite
+  # flips the roles. Deliberately AFTER the prompt-file override, unlike the
+  # language line: this is a fact about the input, not a style choice, so a
+  # custom prompt does not get to be wrong about it.
+  sys="$sys"$'\n\n'"The text you are given is a message the assistant wrote to the user. In it, \"I\", \"me\", and \"my\" refer to the assistant; \"you\" and \"your\" refer to the user. Keep that same point of view in the rewrite — never swap the two, and never address the assistant."
 
   # Context only: the original user question the assistant is answering.
   # Truncated to 800 codepoints inside jq (safe on multibyte boundaries).


### PR DESCRIPTION
## What

The rewrite prompt described the task but never said the input is **one turn of a conversation**. The pronouns in an assistant message therefore had nothing to anchor to: `"I"` could drift onto the rewriter and `"you"` onto the assistant, and a rewrite could come back with the roles inverted.

Every prompt now states that `"I"/"me"/"my"` are the assistant and `"you"/"your"` are the user, and that the rewrite must keep that point of view.

## Where, and why there

The line is appended **after** the `CLAUDISH_PROMPT_FILE` override — not before it, where the output-language line sits. A custom prompt legitimately replaces style and language choices, but this is a fact about the input rather than a preference, so it applies to the default prompt, every style preset, and a custom prompt alike. One insertion point instead of four also sidesteps the "a new preset touches four readers" trap.

## Testing

- `bash -n rewrite.sh` — clean.
- **Fails open.** All three cases print nothing and exit 0:
  - `printf 'not json'` → `rc=0`
  - `printf ''` → `rc=0`
  - `printf '{"session_id":"s","final":true}'` → `rc=0`
- **Display mechanics** via `CLAUDISH_STUB=1 CLAUDISH_STYLE=caveman` — label and separator unchanged.
- **Prompt assembly** verified by sourcing a stand-in `providers.sh` whose `llm_complete` dumps the system prompt: the line is present in the default prompt, in the `caveman` preset, and after a custom `CLAUDISH_PROMPT_FILE` that replaced everything else.

## Notes

- Display-only; no change to Claude's reasoning or the transcript.
- No ANSI, no new env var, no `README.md` change (nothing new to configure).
- `CHANGELOG.md` entry added under `## [Unreleased]` → `### Changed`. `plugin.json` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)