### PR TITLE
chore: v0.9.0 — voice framing in every rewrite prompt, contributor and release docs

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claudish-to-english",
   "description": "Shows a plain-language rewrite of each Claude Code assistant message, produced by a local LLM (ollama, default), the Anthropic API, or any OpenAI-compatible API. Switch it on the fly with /claudish (on/off, append/replace, language, model). Display-only: Claude's reasoning and the transcript keep the original text.",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "author": {
     "name": "Mike Gvozdev",
     "email": "mv.gvozdev@gmail.com",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.9.0] - 2026-08-28
 
 ### Added
 - **Contributor and release documentation.** `CONTRIBUTING.md` covers setup,
@@ -252,7 +252,8 @@ by Davide Di Pumpo, adapted to the provider layer and language resolver.
 - Optional `PostToolUse` Markdown-file rewrite hook (`rewrite-md.sh`), opt-in by
   directory (`CLAUDISH_MD_DIR`), with `sibling` and `overwrite` modes.
 
-[Unreleased]: https://github.com/gvzdv/claudish-to-english/compare/v0.8.0...HEAD
+[Unreleased]: https://github.com/gvzdv/claudish-to-english/compare/v0.9.0...HEAD
+[0.9.0]: https://github.com/gvzdv/claudish-to-english/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/gvzdv/claudish-to-english/compare/v0.7.1...v0.8.0
 [0.7.1]: https://github.com/gvzdv/claudish-to-english/compare/v0.7.0...v0.7.1
 [0.7.0]: https://github.com/gvzdv/claudish-to-english/compare/v0.6.0...v0.7.0


### PR DESCRIPTION
Release cut for **v0.9.0**.

## Why MINOR

SemVer at `0.x`: there are entries under `### Added`, so this is a MINOR bump rather than a PATCH. The `### Changed` entry is a defect fix on its own, but a patch may not carry additions.

## Files changed

Only the two that carry a version:

- `.claude-plugin/plugin.json` — `0.8.0` → `0.9.0`
- `CHANGELOG.md` — `## [Unreleased]` → `## [0.9.0] - 2026-08-28`, new `[0.9.0]` comparison ref, `[Unreleased]` repointed to `compare/v0.9.0...HEAD`

`marketplace.json` pins no version and is untouched.

## What ships

**Added — contributor and release documentation.** `CONTRIBUTING.md` covers setup, testing without a provider (`CLAUDISH_STUB=1`), the fail-open rule that outranks everything else, and the traps that have caused real regressions here. A PR template puts the same checklist in front of every PR, `CLAUDE.md` gives Claude Code the same ground rules automatically, and a `/release` skill executes the release cut in two phases so the version bump, the changelog link refs, and tagging the merge commit stop being things anyone has to remember.

**Changed — every rewrite prompt now states whose voice it is reading.** The input is one turn of a conversation, so the model is told that `"I"/"me"/"my"` are the assistant and `"you"/"your"` are the user, and that the rewrite must keep that point of view. Without it the pronouns had nothing to anchor to and a rewrite could invert the roles. The line is appended after the `CLAUDISH_PROMPT_FILE` override rather than before it, where the output language sits: a custom prompt legitimately replaces style and language choices, but this is a fact about the input, so it applies to every rewrite — default, style preset, and custom prompt alike. (#27)

## Verification

```
jq -r .version .claude-plugin/plugin.json   # 0.9.0, matches the new heading
grep -c '^## \[' CHANGELOG.md               # 12, one more than last release
for f in *.sh; do bash -n "$f"; done        # clean
```

Every `## [x]` heading has a matching `[x]:` ref and there are no orphaned refs.

## After merge

The tag goes on the **merge** commit, not this `chore:` commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
