### PR TITLE
providers.sh: optional mutual-TLS plumbing + ambient-key opt-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- Optional mutual-TLS client authentication for any provider. Three new env
+  vars, all unset by default (additive — no behavior change when unset):
+  - `CLAUDISH_CLIENT_CERT` — passed as `--cert` to every curl call.
+  - `CLAUDISH_CLIENT_KEY` — passed as `--key` when set.
+  - `CLAUDISH_CA_BUNDLE` — passed as `--cacert` for custom trust roots.
+  This is the minimum shape needed to talk to a fleet endpoint terminated by a
+  vLLM server using `--ssl-certfile --ssl-keyfile --ssl-ca-certs
+  --ssl-cert-reqs 2`, or any reverse proxy with the same posture.
+
+### Changed (security)
+- Ambient `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` fallback is OFF by default. A
+  fleet member with a shell profile, direnv, or any environment that exports
+  those names will NOT silently ship every rewrite to a third-party cloud. Set
+  `CLAUDISH_ALLOW_AMBIENT_KEYS=1` to opt back into the previous behavior.
+
 ## [0.9.0] - 2026-08-28
 
 ### Added
@@ -200,6 +218,7 @@ by Davide Di Pumpo, adapted to the provider layer and language resolver.
   still replaces the whole prompt.
 - With no language configured, the display label reads `💬 In plain language:`
   rather than `💬 In plain English:`, which it can no longer promise.
+||||||| parent of 46e7964 (providers.sh: additive mutual TLS plumbing + ambient-key opt-in)
 
 ## [0.3.0] - 2026-08-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -218,8 +218,6 @@ by Davide Di Pumpo, adapted to the provider layer and language resolver.
   still replaces the whole prompt.
 - With no language configured, the display label reads `💬 In plain language:`
   rather than `💬 In plain English:`, which it can no longer promise.
-||||||| parent of 46e7964 (providers.sh: additive mutual TLS plumbing + ambient-key opt-in)
-
 ## [0.3.0] - 2026-08-13
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -446,8 +446,8 @@ ollama, nothing leaves your machine.
 |---|---|---|---|
 | `ollama` (default) | `CLAUDISH_OLLAMA` (`http://localhost:11434`) | none | `gemma4:26b-mlx` |
 | `codex` | OpenAI codex CLI (`codex exec`) — uses the CLI's own login | none | *(CLI default)* |
-| `anthropic` | `CLAUDISH_ANTHROPIC_URL` (`https://api.anthropic.com`) + `/v1/messages` | `CLAUDISH_ANTHROPIC_KEY` or `ANTHROPIC_API_KEY` | `claude-haiku-4-5` |
-| `openai` | `CLAUDISH_OPENAI_URL` + `/chat/completions` | `CLAUDISH_OPENAI_KEY` or `OPENAI_API_KEY` | `gpt-5.6-luna` |
+| `anthropic` | `CLAUDISH_ANTHROPIC_URL` (`https://api.anthropic.com`) + `/v1/messages` | `CLAUDISH_ANTHROPIC_KEY` (or `ANTHROPIC_API_KEY` with `CLAUDISH_ALLOW_AMBIENT_KEYS=1`) | `claude-haiku-4-5` |
+| `openai` | `CLAUDISH_OPENAI_URL` + `/chat/completions` | `CLAUDISH_OPENAI_KEY` (or `OPENAI_API_KEY` with `CLAUDISH_ALLOW_AMBIENT_KEYS=1`) | `gpt-5.6-luna` |
 
 ### codex
 
@@ -561,10 +561,14 @@ Notes:
 | `CLAUDISH_MODEL` | *(per provider)* | Model name; overrides the provider default (see [Providers](#providers)). The ollama default `gemma4:26b-mlx` is MLX (Apple-silicon only; Windows users must override). |
 | `CLAUDISH_MODEL_FILE` | `~/.claude/claudish-model` | Runtime model override: a model name in this file wins over `CLAUDISH_MODEL`, re-checked every message (applies to whatever provider is configured). Written by `/claudish model <name>`. See [Controlling it live](#controlling-it-live-claudish). |
 | `CLAUDISH_OLLAMA` | `http://localhost:11434` | ollama base URL. |
-| `CLAUDISH_ANTHROPIC_KEY` | *(unset)* | Anthropic API key; falls back to `ANTHROPIC_API_KEY`. |
-| `CLAUDISH_OPENAI_KEY` | *(unset)* | OpenAI(-compatible) API key; falls back to `OPENAI_API_KEY`. Only required for api.openai.com. |
+| `CLAUDISH_ANTHROPIC_KEY` | *(unset)* | Anthropic API key. The ambient `ANTHROPIC_API_KEY` only takes effect when `CLAUDISH_ALLOW_AMBIENT_KEYS=1` is set (default unset = no fallback). |
+| `CLAUDISH_OPENAI_KEY` | *(unset)* | OpenAI(-compatible) API key. The ambient `OPENAI_API_KEY` only takes effect when `CLAUDISH_ALLOW_AMBIENT_KEYS=1` is set. Only required for api.openai.com. |
+| `CLAUDISH_ALLOW_AMBIENT_KEYS` | *(unset)* | `1` to opt back into the fallback to `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` when the matching `CLAUDISH_*_KEY` is unset. Default unset — a shell profile, direnv, or any environment that exports the ambient names will NOT silently cause every rewrite to ship to a third-party cloud. |
 | `CLAUDISH_OPENAI_URL` | `https://api.openai.com/v1` | Base URL for any OpenAI-compatible endpoint (LM Studio, llama.cpp server, vLLM, OpenRouter, ...). Trailing slashes are ignored. |
 | `CLAUDISH_ANTHROPIC_URL` | `https://api.anthropic.com` | Base URL for the anthropic provider — override for proxies/gateways that speak the Messages API. |
+| `CLAUDISH_CLIENT_CERT` | *(unset)* | Path to a PEM-format client certificate (or a combined cert+key PEM). When set, every curl call passes `--cert <path>` — used to talk to a fleet endpoint that requires mutual TLS (e.g., a vLLM server started with `--ssl-certfile --ssl-keyfile --ssl-ca-certs --ssl-cert-reqs 2`). |
+| `CLAUDISH_CLIENT_KEY` | *(unset)* | Path to a PEM-format client private key, if it is not combined with `CLAUDISH_CLIENT_CERT`. When set, every curl call passes `--key <path>`. |
+| `CLAUDISH_CA_BUNDLE` | *(unset)* | Path to a PEM-format CA bundle to trust the endpoint certificate against. When set, every curl call passes `--cacert <path>`. When unset, the system trust store is used. |
 | `CLAUDISH_OPENAI_EFFORT` | `none` on api.openai.com, else *(unset)* | `reasoning_effort` sent with openai-provider requests. Set explicitly empty to omit the field. |
 | `CLAUDISH_CODEX_EFFORT` | *(unset)* | `model_reasoning_effort` for the codex provider (e.g. `low`). Unset uses the codex CLI's configured effort. Applies to the rewrite only. |
 | `CLAUDISH_MAX_TOKENS` | `4096` | Completion cap for the anthropic provider. Rewrites that hit the cap are discarded (fail-open), with a notice to raise it. |

--- a/providers.sh
+++ b/providers.sh
@@ -21,12 +21,35 @@
 #              CLI's own login, so no API key and no local model server. The
 #              rewrite runs with --sandbox read-only outside any repo.
 #   anthropic  Anthropic Messages API; key from CLAUDISH_ANTHROPIC_KEY or
-#              ANTHROPIC_API_KEY; base URL from CLAUDISH_ANTHROPIC_URL
+#              ANTHROPIC_API_KEY (the latter only when CLAUDISH_ALLOW_AMBIENT_KEYS=1);
+#              base URL from CLAUDISH_ANTHROPIC_URL
 #   openai     any OpenAI-compatible /chat/completions endpoint (OpenAI,
 #              LM Studio, llama.cpp server, vLLM, OpenRouter, ...); base URL
 #              from CLAUDISH_OPENAI_URL, key from CLAUDISH_OPENAI_KEY or
-#              OPENAI_API_KEY. A key is only required for the default
-#              api.openai.com URL — local servers work keyless.
+#              OPENAI_API_KEY (the latter only when CLAUDISH_ALLOW_AMBIENT_KEYS=1).
+#              A key is only required for the default api.openai.com URL —
+#              local servers work keyless.
+#
+# Mutual TLS (optional, additive — all three vars unset = same behavior as before):
+#   CLAUDISH_CLIENT_CERT     PEM-format client certificate (path); combined cert+key
+#                            PEM is accepted here as well as a separate file
+#   CLAUDISH_CLIENT_KEY      PEM-format client private key (path), if not combined
+#                            with the cert
+#   CLAUDISH_CA_BUNDLE       PEM-format CA bundle to trust the endpoint certificate
+#                            against (if unset, the system trust store is used)
+#   The three flags above are passed to every curl invocation via --cert,
+#   --key, --cacert, in that order, exactly once each, regardless of provider.
+#   This is the minimum needed to talk to a fleet endpoint terminated by a
+#   vLLM server using --ssl-certfile / --ssl-keyfile / --ssl-ca-certs /
+#   --ssl-cert-reqs 2 (or any reverse proxy that requires a client cert).
+#
+# Ambient key opt-in (security; default off):
+#   CLAUDISH_ALLOW_AMBIENT_KEYS=1  permit fallback to ANTHROPIC_API_KEY /
+#                                  OPENAI_API_KEY when CLAUDISH_ANTHROPIC_KEY /
+#                                  CLAUDISH_OPENAI_KEY is unset. Default unset
+#                                  (silent fleet-leak guard: a direnv or shell
+#                                  profile that exports these will NOT cause
+#                                  every rewrite to ship to a third-party cloud).
 #
 # Extra config:
 #   CLAUDISH_MODEL          overrides the per-provider default model
@@ -62,8 +85,17 @@ OLLAMA="${CLAUDISH_OLLAMA:-http://localhost:11434}"
 # https://api.anthropic.com: oauth mode refuses to run with a
 # CLAUDISH_ANTHROPIC_URL override, so the credential cannot leak to a proxy.
 ANTHROPIC_AUTH="${CLAUDISH_ANTHROPIC_AUTH:-}"
-ANTHROPIC_KEY="${CLAUDISH_ANTHROPIC_KEY:-${ANTHROPIC_API_KEY:-}}"
-OPENAI_KEY="${CLAUDISH_OPENAI_KEY:-${OPENAI_API_KEY:-}}"
+# Ambient-key fallback is OFF by default. A shell profile, direnv, or any
+# environment that already exports ANTHROPIC_API_KEY or OPENAI_API_KEY would
+# otherwise ship every rewrite silently to that cloud. Set
+# CLAUDISH_ALLOW_AMBIENT_KEYS=1 to opt back into the previous behavior.
+if [ "${CLAUDISH_ALLOW_AMBIENT_KEYS:-0}" = "1" ]; then
+  ANTHROPIC_KEY="${CLAUDISH_ANTHROPIC_KEY:-${ANTHROPIC_API_KEY:-}}"
+  OPENAI_KEY="${CLAUDISH_OPENAI_KEY:-${OPENAI_API_KEY:-}}"
+else
+  ANTHROPIC_KEY="${CLAUDISH_ANTHROPIC_KEY:-}"
+  OPENAI_KEY="${CLAUDISH_OPENAI_KEY:-}"
+fi
 OPENAI_URL="${CLAUDISH_OPENAI_URL:-https://api.openai.com/v1}"
 ANTHROPIC_URL="${CLAUDISH_ANTHROPIC_URL:-https://api.anthropic.com}"
 MAX_TOKENS="${CLAUDISH_MAX_TOKENS:-4096}"
@@ -137,6 +169,13 @@ llm_complete() {
   _sys="$1"; _user="$2"
   rewrite=""; curl_rc=0; err=""; resp=""; http=""; finish=""; truncated=0
   hdrfile=""; cfgerr=0
+  # Build the optional mTLS flag list exactly once per call. With all three
+  # vars unset the array is empty and ${arr[@]+...} expansion yields nothing,
+  # so the curl argv is byte-for-byte unchanged from upstream v0.3.0.
+  CURL_TLS=()
+  [ -n "${CLAUDISH_CLIENT_CERT:-}" ] && CURL_TLS+=(--cert "${CLAUDISH_CLIENT_CERT}")
+  [ -n "${CLAUDISH_CLIENT_KEY:-}"  ] && CURL_TLS+=(--key  "${CLAUDISH_CLIENT_KEY}")
+  [ -n "${CLAUDISH_CA_BUNDLE:-}"   ] && CURL_TLS+=(--cacert "${CLAUDISH_CA_BUNDLE}")
   case "$PROVIDER" in
     anthropic)
       _oauth_hdrs=()
@@ -225,6 +264,7 @@ llm_complete() {
       # in the path (it is always set — reset to "" at the top of this call).
       trap 'rm -f "$hdrfile" 2>/dev/null' EXIT
       resp="$(printf '%s' "$req" | curl -sS --max-time "$LLM_TIMEOUT" -w '\n%{http_code}' \
+              ${CURL_TLS[@]+"${CURL_TLS[@]}"} \
               -K "$hdrfile" -H 'Content-Type: application/json' \
               -H 'anthropic-version: 2023-06-01' \
               ${_oauth_hdrs[@]+"${_oauth_hdrs[@]}"} \
@@ -260,6 +300,7 @@ llm_complete() {
         auth=(-K "$hdrfile")
       fi
       resp="$(printf '%s' "$req" | curl -sS --max-time "$LLM_TIMEOUT" -w '\n%{http_code}' \
+              ${CURL_TLS[@]+"${CURL_TLS[@]}"} \
               -H 'Content-Type: application/json' ${auth[@]+"${auth[@]}"} \
               -X POST "$OPENAI_URL/chat/completions" -d @- 2>/dev/null)"
       curl_rc=$?
@@ -314,6 +355,7 @@ $_user" >/dev/null 2>"$_errf" &
             '{model:$m,stream:false,think:false,options:{temperature:0.3},messages:[{role:"system",content:$s},{role:"user",content:$u}]}' 2>/dev/null)"
       [ -n "$req" ] || return 2
       resp="$(printf '%s' "$req" | curl -sS --max-time "$LLM_TIMEOUT" \
+              ${CURL_TLS[@]+"${CURL_TLS[@]}"} \
               -H 'Content-Type: application/json' -X POST "$OLLAMA/api/chat" -d @- 2>/dev/null)"
       curl_rc=$?
       rewrite="$(printf '%s' "$resp" | jq -j '.message.content // empty' 2>/dev/null)"
@@ -361,7 +403,7 @@ llm_notice_why() {
       elif [ "$ANTHROPIC_AUTH" = "oauth" ] && [ -z "$ANTHROPIC_KEY" ]; then
         NOTICE_WHY="could not read a fresh Claude Code access token (macOS login Keychain, or ~/.claude/.credentials.json elsewhere) — check that Claude Code is logged in; rewrites are off"
       elif [ -z "$ANTHROPIC_KEY" ]; then
-        NOTICE_WHY="no Anthropic API key in this session's environment (set CLAUDISH_ANTHROPIC_KEY or ANTHROPIC_API_KEY), so rewrites are off"
+        NOTICE_WHY="no Anthropic API key in this session's environment (set CLAUDISH_ANTHROPIC_KEY, or ANTHROPIC_API_KEY together with CLAUDISH_ALLOW_AMBIENT_KEYS=1), so rewrites are off"
       elif [ "${truncated:-0}" = "1" ]; then
         NOTICE_WHY="the rewrite hit the ${MAX_TOKENS}-token output cap and was discarded rather than shown half-finished — raise CLAUDISH_MAX_TOKENS"
       elif [ -n "${err:-}" ]; then
@@ -374,7 +416,7 @@ llm_notice_why() {
       ;;
     openai)
       if [ -z "$OPENAI_KEY" ] && [ "$OPENAI_URL" = "https://api.openai.com/v1" ]; then
-        NOTICE_WHY="no OpenAI API key in this session's environment (set CLAUDISH_OPENAI_KEY or OPENAI_API_KEY), so rewrites are off"
+        NOTICE_WHY="no OpenAI API key in this session's environment (set CLAUDISH_OPENAI_KEY, or OPENAI_API_KEY together with CLAUDISH_ALLOW_AMBIENT_KEYS=1), so rewrites are off"
       elif [ "${cfgerr:-0}" = "1" ]; then
         NOTICE_WHY="${err:-provider configuration error}"
       elif [ "${truncated:-0}" = "1" ]; then

--- a/providers.sh
+++ b/providers.sh
@@ -171,7 +171,7 @@ llm_complete() {
   hdrfile=""; cfgerr=0
   # Build the optional mTLS flag list exactly once per call. With all three
   # vars unset the array is empty and ${arr[@]+...} expansion yields nothing,
-  # so the curl argv is byte-for-byte unchanged from upstream v0.3.0.
+  # so the curl argv is byte-for-byte unchanged when these vars are unset.
   CURL_TLS=()
   [ -n "${CLAUDISH_CLIENT_CERT:-}" ] && CURL_TLS+=(--cert "${CLAUDISH_CLIENT_CERT}")
   [ -n "${CLAUDISH_CLIENT_KEY:-}"  ] && CURL_TLS+=(--key  "${CLAUDISH_CLIENT_KEY}")


### PR DESCRIPTION
## What this changes

One provider-safety change for private fleet endpoints, with two parts:

1. **Optional mutual TLS.** Three new environment variables are passed to every
   curl-backed provider when set. With all three unset, the request argv is
   unchanged:

   - `CLAUDISH_CLIENT_CERT` maps to `--cert`
   - `CLAUDISH_CLIENT_KEY` maps to `--key`
   - `CLAUDISH_CA_BUNDLE` maps to `--cacert`

   This is the minimum client-side configuration needed to talk directly to a
   vLLM server started with `--ssl-certfile --ssl-keyfile --ssl-ca-certs
   --ssl-cert-reqs 2`, or to a reverse proxy with the same mTLS posture.

2. **Explicit ambient-key fallback.** This is an intentional security default
   change. `ANTHROPIC_API_KEY` and `OPENAI_API_KEY` are ignored unless
   `CLAUDISH_ALLOW_AMBIENT_KEYS=1` is set. Provider-specific
   `CLAUDISH_ANTHROPIC_KEY` and `CLAUDISH_OPENAI_KEY` continue to work without
   that opt-in and take precedence when both forms exist.

   This prevents a shell profile, direnv, or fleet environment from silently
   authenticating rewrites to a default third-party cloud endpoint. Users who
   relied on the previous ambient fallback must either set
   `CLAUDISH_ALLOW_AMBIENT_KEYS=1` or use the provider-specific key variable.
   Anthropic OAuth remains separate and never consumes an ambient API key.

## How I tested it

- `git diff --check` passes and a repository-wide conflict-marker scan is clean.
- `bash -n` passes on all six shell scripts.
- Stub-mode end to end produces `STUB-SIMPLIFIED` with `prose_len=560`.
- Malformed JSON, empty input, and a missing `message_id` each emit zero bytes
  and exit 0.
- The ambient-key matrix proves default-off, exact `=1` opt-in, explicit-key
  precedence, and rejection of other truthy values such as `true`.
- Anthropic OAuth discards an ambient key even when ambient fallback is enabled.
- Mock-curl argv tests cover Ollama, OpenAI-compatible, and Anthropic calls.
  Against current `main`, unset TLS variables produce byte-identical argv after
  fixing the mock key-file path. When enabled, `--cert`, `--key`, and `--cacert`
  each occur exactly once, in order, and paths containing spaces remain one
  argument.

---

## Checklist

- [x] `bash -n` passes on every shell script
- [x] **Fails open**: bad input, empty payload, and missing `message_id` emit
      nothing and exit 0, preserving Claude's original text
- [x] `CHANGELOG.md` entry added under `## [Unreleased]`
- [x] `.claude-plugin/plugin.json` was not bumped and no tag was created
- [x] `README.md` documents the new environment variables and ambient-key rule
