### PR TITLE
feat: add orcarouter as a named provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **An `orcarouter` provider** (`CLAUDISH_PROVIDER=orcarouter`): rewrites go
+  through [OrcaRouter](https://www.orcarouter.ai)'s OpenAI-compatible
+  `/chat/completions` endpoint (`https://api.orcarouter.ai/v1`), which routes
+  across many upstream models with automatic failover. Key from
+  `CLAUDISH_ORCAROUTER_KEY` or `ORCAROUTER_API_KEY`; base URL override
+  `CLAUDISH_ORCAROUTER_URL`; default model `orcarouter/auto` (override with
+  `CLAUDISH_MODEL`).
+
 ## [0.9.0] - 2026-08-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -448,6 +448,7 @@ ollama, nothing leaves your machine.
 | `codex` | OpenAI codex CLI (`codex exec`) — uses the CLI's own login | none | *(CLI default)* |
 | `anthropic` | `CLAUDISH_ANTHROPIC_URL` (`https://api.anthropic.com`) + `/v1/messages` | `CLAUDISH_ANTHROPIC_KEY` or `ANTHROPIC_API_KEY` | `claude-haiku-4-5` |
 | `openai` | `CLAUDISH_OPENAI_URL` + `/chat/completions` | `CLAUDISH_OPENAI_KEY` or `OPENAI_API_KEY` | `gpt-5.6-luna` |
+| `orcarouter` | `CLAUDISH_ORCAROUTER_URL` (`https://api.orcarouter.ai/v1`) + `/chat/completions` | `CLAUDISH_ORCAROUTER_KEY` or `ORCAROUTER_API_KEY` | `orcarouter/auto` |
 
 ### codex
 
@@ -515,6 +516,12 @@ export CLAUDISH_MODEL=gpt-5.6-luna          # the default; override to taste
 export CLAUDISH_PROVIDER=openai
 export CLAUDISH_OPENAI_URL=http://localhost:1234/v1
 export CLAUDISH_MODEL=qwen3-30b
+
+# OrcaRouter — an OpenAI-compatible gateway, as a named provider. A key is
+# always required. `orcarouter/auto` routes to an upstream model automatically.
+export CLAUDISH_PROVIDER=orcarouter
+export ORCAROUTER_API_KEY=sk-orca-...
+export CLAUDISH_MODEL=orcarouter/auto      # the default; override to taste
 ```
 
 Notes:
@@ -529,8 +536,8 @@ Notes:
 - The anthropic provider caps completions at `CLAUDISH_MAX_TOKENS` (default
   4096, since the Messages API requires an explicit cap).
 - A rewrite that hits an output-token cap is **discarded**, not shown — on the
-  ollama, anthropic, and openai providers (ollama's `done_reason: "length"`
-  included): a half-finished
+  ollama, anthropic, openai, and orcarouter providers (ollama's
+  `done_reason: "length"` included): a half-finished
   rewrite on screen is confusing, and in the Markdown hook's `overwrite` mode
   it would replace your real document. You get the original text plus the
   once-per-session notice suggesting a higher cap.
@@ -557,13 +564,15 @@ Notes:
 | `CLAUDISH_PROMPT_FILE` | *(unset)* | Path to a file whose contents replace the display hook's system prompt (whole prompt, not merged). Empty/unreadable falls back to the built-in default. See [Customizing the rewrite prompt](#customizing-the-rewrite-prompt). |
 | `CLAUDISH_LANG` | *(unset)* | Language to rewrite into, e.g. `Esperanto`. Unset falls back to the `language` key in `.claude/settings*.json`; with neither set, the rewrite keeps the input's language. Empty ignores the settings key; `English` forces English. See [Output language](#output-language). |
 | `CLAUDISH_LANG_FILE` | `~/.claude/claudish-lang` | Runtime language override: a language name in this file wins over `CLAUDISH_LANG` and the settings key, re-checked every message. Written by `/claudish language <name>`. See [Controlling it live](#controlling-it-live-claudish). |
-| `CLAUDISH_PROVIDER` | `ollama` | `ollama`, `codex`, `anthropic`, or `openai` — which LLM serves rewrites (both hooks). |
+| `CLAUDISH_PROVIDER` | `ollama` | `ollama`, `codex`, `anthropic`, `openai`, or `orcarouter` — which LLM serves rewrites (both hooks). |
 | `CLAUDISH_MODEL` | *(per provider)* | Model name; overrides the provider default (see [Providers](#providers)). The ollama default `gemma4:26b-mlx` is MLX (Apple-silicon only; Windows users must override). |
 | `CLAUDISH_MODEL_FILE` | `~/.claude/claudish-model` | Runtime model override: a model name in this file wins over `CLAUDISH_MODEL`, re-checked every message (applies to whatever provider is configured). Written by `/claudish model <name>`. See [Controlling it live](#controlling-it-live-claudish). |
 | `CLAUDISH_OLLAMA` | `http://localhost:11434` | ollama base URL. |
 | `CLAUDISH_ANTHROPIC_KEY` | *(unset)* | Anthropic API key; falls back to `ANTHROPIC_API_KEY`. |
 | `CLAUDISH_OPENAI_KEY` | *(unset)* | OpenAI(-compatible) API key; falls back to `OPENAI_API_KEY`. Only required for api.openai.com. |
 | `CLAUDISH_OPENAI_URL` | `https://api.openai.com/v1` | Base URL for any OpenAI-compatible endpoint (LM Studio, llama.cpp server, vLLM, OpenRouter, ...). Trailing slashes are ignored. |
+| `CLAUDISH_ORCAROUTER_KEY` | *(unset)* | OrcaRouter API key; falls back to `ORCAROUTER_API_KEY`. Always required. |
+| `CLAUDISH_ORCAROUTER_URL` | `https://api.orcarouter.ai/v1` | Base URL for OrcaRouter's OpenAI-compatible endpoint. Trailing slashes are ignored. |
 | `CLAUDISH_ANTHROPIC_URL` | `https://api.anthropic.com` | Base URL for the anthropic provider — override for proxies/gateways that speak the Messages API. |
 | `CLAUDISH_OPENAI_EFFORT` | `none` on api.openai.com, else *(unset)* | `reasoning_effort` sent with openai-provider requests. Set explicitly empty to omit the field. |
 | `CLAUDISH_CODEX_EFFORT` | *(unset)* | `model_reasoning_effort` for the codex provider (e.g. `low`). Unset uses the codex CLI's configured effort. Applies to the rewrite only. |
@@ -623,11 +632,11 @@ see — much slower for identical output quality on this simple task. Keep it of
 
 With the default provider the rewriter runs **entirely locally** against
 ollama, so **no conversation content leaves your machine**. Setting
-`CLAUDISH_PROVIDER` to `anthropic` or `openai` changes that deliberately: every
-rewritten assistant message (and, with the Markdown hook enabled, file
-contents) is sent to that API. The same applies to pointing `CLAUDISH_OLLAMA`
-or `CLAUDISH_OPENAI_URL` at a remote/hosted endpoint. Don't switch away from
-local unless you understand and accept it.
+`CLAUDISH_PROVIDER` to `anthropic`, `openai`, or `orcarouter` changes that
+deliberately: every rewritten assistant message (and, with the Markdown hook
+enabled, file contents) is sent to that API. The same applies to pointing
+`CLAUDISH_OLLAMA` or `CLAUDISH_OPENAI_URL` at a remote/hosted endpoint. Don't
+switch away from local unless you understand and accept it.
 
 ---
 
@@ -646,7 +655,7 @@ claudish-to-english/
 ├── rewrite-md.sh           # markdown-file rewrite hook (opt-in)
 ├── claudish-ctl.sh         # runtime state switcher + dashboard backing /claudish (writes the flag files)
 ├── session-notice.sh       # SessionStart hook: announces leftover /claudish overrides on a new session
-├── providers.sh            # provider layer (ollama/anthropic/openai), sourced by both hooks
+├── providers.sh            # provider layer (ollama/anthropic/openai/orcarouter), sourced by both hooks
 ├── lang.sh                 # output-language resolver (env + .claude/settings*.json), sourced by both hooks
 ├── CHANGELOG.md            # notable changes per version (Keep a Changelog)
 ├── LICENSE

--- a/providers.sh
+++ b/providers.sh
@@ -27,6 +27,10 @@
 #              from CLAUDISH_OPENAI_URL, key from CLAUDISH_OPENAI_KEY or
 #              OPENAI_API_KEY. A key is only required for the default
 #              api.openai.com URL — local servers work keyless.
+#   orcarouter OrcaRouter's OpenAI-compatible /chat/completions endpoint
+#              (https://api.orcarouter.ai/v1); base URL from
+#              CLAUDISH_ORCAROUTER_URL, key from CLAUDISH_ORCAROUTER_KEY or
+#              ORCAROUTER_API_KEY. A key is always required.
 #
 # Extra config:
 #   CLAUDISH_MODEL          overrides the per-provider default model
@@ -66,12 +70,15 @@ ANTHROPIC_KEY="${CLAUDISH_ANTHROPIC_KEY:-${ANTHROPIC_API_KEY:-}}"
 OPENAI_KEY="${CLAUDISH_OPENAI_KEY:-${OPENAI_API_KEY:-}}"
 OPENAI_URL="${CLAUDISH_OPENAI_URL:-https://api.openai.com/v1}"
 ANTHROPIC_URL="${CLAUDISH_ANTHROPIC_URL:-https://api.anthropic.com}"
+ORCAROUTER_URL="${CLAUDISH_ORCAROUTER_URL:-https://api.orcarouter.ai/v1}"
+ORCAROUTER_KEY="${CLAUDISH_ORCAROUTER_KEY:-${ORCAROUTER_API_KEY:-}}"
 MAX_TOKENS="${CLAUDISH_MAX_TOKENS:-4096}"
 
 # Normalize away trailing slashes BEFORE any URL comparison, so
 # ".../v1/" gets the same key requirement and effort default as ".../v1".
 while [ "${OPENAI_URL%/}" != "$OPENAI_URL" ]; do OPENAI_URL="${OPENAI_URL%/}"; done
 while [ "${ANTHROPIC_URL%/}" != "$ANTHROPIC_URL" ]; do ANTHROPIC_URL="${ANTHROPIC_URL%/}"; done
+while [ "${ORCAROUTER_URL%/}" != "$ORCAROUTER_URL" ]; do ORCAROUTER_URL="${ORCAROUTER_URL%/}"; done
 
 # An explicitly set CLAUDISH_OPENAI_EFFORT always wins — including an
 # explicitly EMPTY one, which omits the field (the escape hatch for models
@@ -86,10 +93,11 @@ else
 fi
 
 case "$PROVIDER" in
-  anthropic) MODEL="${CLAUDISH_MODEL:-claude-haiku-4-5}" ;;
-  openai)    MODEL="${CLAUDISH_MODEL:-gpt-5.6-luna}" ;;
-  codex)     MODEL="${CLAUDISH_MODEL:-}" ;;  # empty = the codex CLI's configured default
-  *)         MODEL="${CLAUDISH_MODEL:-gemma4:26b-mlx}" ;;
+  anthropic)   MODEL="${CLAUDISH_MODEL:-claude-haiku-4-5}" ;;
+  openai)      MODEL="${CLAUDISH_MODEL:-gpt-5.6-luna}" ;;
+  orcarouter)  MODEL="${CLAUDISH_MODEL:-orcarouter/auto}" ;;
+  codex)       MODEL="${CLAUDISH_MODEL:-}" ;;  # empty = the codex CLI's configured default
+  *)           MODEL="${CLAUDISH_MODEL:-gemma4:26b-mlx}" ;;
 esac
 
 # Runtime model override written by /claudish (claudish-ctl.sh): a file re-read
@@ -270,6 +278,36 @@ llm_complete() {
       finish="$(printf '%s' "$resp" | jq -r '.choices[0].finish_reason // empty' 2>/dev/null)"
       [ "$finish" = "length" ] && { truncated=1; rewrite=""; }
       ;;
+    orcarouter)
+      # OrcaRouter is OpenAI-compatible (/chat/completions) but a key is
+      # ALWAYS required — there is no keyless local mode, so an unset key is
+      # treated exactly like api.openai.com is above.
+      if [ -z "$ORCAROUTER_KEY" ]; then
+        dbg "orcarouter: no key"; curl_rc=1; return 0
+      fi
+      # No reasoning_effort: OrcaRouter routes across many upstreams, and some
+      # reject unknown fields (same rule as custom compat URLs above).
+      req="$(jq -n --arg m "$MODEL" --arg s "$_sys" --arg u "$_user" \
+            '{model:$m,messages:[{role:"system",content:$s},{role:"user",content:$u}]}' 2>/dev/null)"
+      [ -n "$req" ] || return 2
+      hdrfile="$(_llm_key_file "Authorization" "Bearer $ORCAROUTER_KEY")"
+      if [ -z "$hdrfile" ]; then
+        cfgerr=1
+        err="could not create a private temp file for the API key under ${TMPDIR:-/tmp} — nothing was sent"
+        return 0
+      fi
+      trap 'rm -f "$hdrfile" 2>/dev/null' EXIT
+      resp="$(printf '%s' "$req" | curl -sS --max-time "$LLM_TIMEOUT" -w '\n%{http_code}' \
+              -H 'Content-Type: application/json' -K "$hdrfile" \
+              -X POST "$ORCAROUTER_URL/chat/completions" -d @- 2>/dev/null)"
+      curl_rc=$?
+      rm -f "$hdrfile" 2>/dev/null
+      _llm_split_status
+      rewrite="$(printf '%s' "$resp" | jq -j '.choices[0].message.content // empty' 2>/dev/null)"
+      err="$(printf '%s' "$resp" | jq -r 'if (.error|type)=="object" then (.error.message // empty) else (.error // empty) end' 2>/dev/null)"
+      finish="$(printf '%s' "$resp" | jq -r '.choices[0].finish_reason // empty' 2>/dev/null)"
+      [ "$finish" = "length" ] && { truncated=1; rewrite=""; }
+      ;;
     codex)
       if ! command -v codex >/dev/null 2>&1; then
         dbg "codex: CLI not found"; curl_rc=1; return 0
@@ -338,6 +376,7 @@ $_user" >/dev/null 2>"$_errf" &
       5??|429) err="HTTP $http from the endpoint — it may be down, overloaded, or rate-limiting" ;;
       *)   case "$PROVIDER" in
              anthropic) err="HTTP $http with no error message in the response — check that CLAUDISH_ANTHROPIC_URL points at an Anthropic-compatible API base URL" ;;
+             orcarouter) err="HTTP $http with no error message in the response — check that CLAUDISH_ORCAROUTER_URL points at an OpenAI-compatible API base URL (usually ending in /v1)" ;;
              *)         err="HTTP $http with no error message in the response — check that CLAUDISH_OPENAI_URL points at an OpenAI-compatible API base URL (usually ending in /v1)" ;;
            esac ;;
     esac
@@ -385,6 +424,24 @@ llm_notice_why() {
         NOTICE_WHY="the rewrite timed out after ${LLM_TIMEOUT}s — ${TIMEOUT_HINT:-raise the timeout}"
       elif [ "$curl_rc" != "0" ]; then
         NOTICE_WHY="cannot reach ${OPENAI_URL} (curl exit $curl_rc)"
+      fi
+      ;;
+    orcarouter)
+      # First check that mirrors openai: an unset key against the default URL.
+      # A custom URL (self-hosted, a mirror) still requires a key, but the
+      # generic no-key wording is only right for the hosted endpoint.
+      if [ -z "$ORCAROUTER_KEY" ] && [ "$ORCAROUTER_URL" = "https://api.orcarouter.ai/v1" ]; then
+        NOTICE_WHY="no OrcaRouter API key in this session's environment (set CLAUDISH_ORCAROUTER_KEY or ORCAROUTER_API_KEY), so rewrites are off"
+      elif [ "${cfgerr:-0}" = "1" ]; then
+        NOTICE_WHY="${err:-provider configuration error}"
+      elif [ "${truncated:-0}" = "1" ]; then
+        NOTICE_WHY="the rewrite hit the model's output-token limit and was discarded rather than shown half-finished — use a shorter message, or raise the completion cap if you run the server yourself"
+      elif [ -n "${err:-}" ]; then
+        NOTICE_WHY="OrcaRouter API error: ${err}"
+      elif [ "$curl_rc" = "28" ]; then
+        NOTICE_WHY="the rewrite timed out after ${LLM_TIMEOUT}s — ${TIMEOUT_HINT:-raise the timeout}"
+      elif [ "$curl_rc" != "0" ]; then
+        NOTICE_WHY="cannot reach ${ORCAROUTER_URL} (curl exit $curl_rc)"
       fi
       ;;
     codex)

--- a/rewrite-md.sh
+++ b/rewrite-md.sh
@@ -44,7 +44,7 @@
 #                                     rewrites. Set it EMPTY to ignore the settings
 #                                     key, or to "English" to force English.
 #                                     See lang.sh
-#   CLAUDISH_PROVIDER  ollama|anthropic|openai  which LLM serves rewrites (default
+#   CLAUDISH_PROVIDER  ollama|anthropic|openai|orcarouter  which LLM serves rewrites (default
 #                                     ollama; keys, base URLs, and per-provider model
 #                                     defaults are documented in providers.sh)
 #   CLAUDISH_MODEL     <model>        overrides the provider's default model
@@ -87,7 +87,7 @@ pass_through() { dbg "pass_through: ${1:-}"; exit 0; }
 
 SELF_DIR="$(cd "$(dirname "$0")" && pwd)"
 
-# Provider layer (ollama/anthropic/openai): MODEL/OLLAMA defaults,
+# Provider layer (ollama/anthropic/openai/orcarouter): MODEL/OLLAMA defaults,
 # llm_complete, llm_notice_why. Missing file -> fail open.
 . "$SELF_DIR/providers.sh" 2>/dev/null || pass_through "no providers.sh"
 

--- a/rewrite.sh
+++ b/rewrite.sh
@@ -62,7 +62,7 @@
 #                                          Set it EMPTY to ignore the settings
 #                                          key, or to "English" to force
 #                                          English. See lang.sh
-#   CLAUDISH_PROVIDER  ollama|anthropic|openai  which LLM serves rewrites
+#   CLAUDISH_PROVIDER  ollama|anthropic|openai|orcarouter  which LLM serves rewrites
 #                                           (default ollama; keys, base URLs,
 #                                           and per-provider model defaults
 #                                           are documented in providers.sh)
@@ -131,7 +131,7 @@ pass_through() { dbg "pass_through"; exit 0; }
 
 SELF_DIR="$(cd "$(dirname "$0")" && pwd)"
 
-# Provider layer (ollama/anthropic/openai): MODEL/OLLAMA defaults,
+# Provider layer (ollama/anthropic/openai/orcarouter): MODEL/OLLAMA defaults,
 # llm_complete, llm_notice_why. Missing file -> fail open.
 . "$SELF_DIR/providers.sh" 2>/dev/null || pass_through
 


### PR DESCRIPTION
Adds `orcarouter` to the provider layer in `providers.sh`, alongside the existing `ollama` / `codex` / `anthropic` / `openai` choices. This plugin's "plain-English rewrite of each assistant message" currently reaches OpenRouter only as a generic OpenAI-compatible `CLAUDISH_OPENAI_URL`; this makes [OrcaRouter](https://www.orcarouter.ai) a first-class provider in that same table. OrcaRouter is an OpenAI-compatible AI gateway built for both models and agents — like OpenRouter it exposes a provider/model namespace across many models, but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding it as a named provider means users get that stack (and `orcarouter/auto` routing) without treating it as an anonymous custom base URL. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

The implementation mirrors the existing `openai` branch in `providers.sh` (key via `CLAUDISH_ORCAROUTER_KEY` or `ORCAROUTER_API_KEY`, base URL override `CLAUDISH_ORCAROUTER_URL`, default model `orcarouter/auto`), so both hooks and their fail-open behaviour are unchanged. Docs: new row in the Providers table, an example in the providers block, `CLAUDISH_ORCAROUTER_*` rows in the Configuration table, the Privacy/egress wording, and a `CHANGELOG.md` entry under `## [Unreleased]`. `.claude-plugin/plugin.json` is untouched.

Verified:
- `bash -n` passes on `providers.sh`, `rewrite.sh`, `rewrite-md.sh`
- Fail-open holds: `printf 'not json' | bash rewrite.sh`, empty payload, and a missing `message_id` each print nothing and exit 0
- `CLAUDISH_STUB=1` end-to-end display test still emits the stub rewrite
- Live: `CLAUDISH_PROVIDER=orcarouter CLAUDISH_MODEL=orcarouter/auto` through `rewrite.sh` returned HTTP 200 and appended the 💬 rewrite block (the once-per-session notice did not fire)

Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter

I'm an engineer on the OrcaRouter team.